### PR TITLE
Game Orchestrator in Dedicated Thread

### DIFF
--- a/src/poker/gameorchestrator.h
+++ b/src/poker/gameorchestrator.h
@@ -36,11 +36,13 @@ public:
      * @param[in]  gameAnalyzer    pointer to an instance of an actual PokerGame subclass
      * @param[in]  nbHandsToPlay   number of hands to play simultaneously (usually will be 1)
      * @param[in]  playerAcct      reference to an account for managing the credits available for betting/winning
+     * @param[in]  renderDelay     delay between card draws in milliseconds
      * @param[in]  parent          QObject parent pointer
      */
     explicit GameOrchestrator(PokerGame *gameAnalyzer,
                               quint32    nbHandsToPlay,
                               Account   &playerAcct,
+                              quint8     renderDelay,
                               QObject   *parent = nullptr);
 
     /**
@@ -124,6 +126,15 @@ public slots:
      */
     void betMaximum();
 
+    /**
+     * @brief speedControl will adjust the delay between card draws:
+     *
+     *            +--> Instant --> Slow 150ms --> Medium 100ms --> Fast 50ms ---+
+     *            |                                                             |
+     *            +-------------------------------------------------------------+
+     */
+    void speedControlCycle();
+
 signals:
     /**
      * @brief betUpdated is emitted when the user requested a bet amount change and a new paytable should be shown
@@ -134,6 +145,11 @@ signals:
      * @brief newGameStarted is emitted when a new game has begun to be dealt (allowing the UI to react and reset)
      */
     void newGameStarted();
+
+    /**
+     * @brief cardsToRedraw is emitted with the status (true) of cards that will be redrawn (for the sake of the UI)
+     */
+    void cardsToRedraw(bool card1, bool card2, bool card3, bool card4, bool card5);
 
     /**
      * @brief gameInProgress indicates a game is in progress and the next dealDraw call will be a draw, not a full deal
@@ -160,10 +176,16 @@ signals:
      */
     void primaryCardRevealed(int cardIdx, PlayingCard card);
 
+    /**
+     * @brief renderSpeed indicates the card draw speed was changed
+     */
+    void renderSpeed(const QString &currentSpeed);
+
 private:
     PokerGame                  *_gameAnalyzer;
     quint32                     _nbHandsPerBet;
     Account                    &_playerAccount;
+    quint8                      _renderDelayMS;
     bool                        _fakeGame;
     bool                        _handInProg;
     QVector<QPair<Deck, Hand>>  _gameCards;

--- a/src/ui/gameorchestratorwindow.h
+++ b/src/ui/gameorchestratorwindow.h
@@ -53,6 +53,9 @@ public slots:
     // Update the account balance widget as the totals are created
     void currentBalance(quint32 totalCredits);
 
+    // Sets the render speed indicator on the speed button
+    void updateSpeedChar(const QString &speedStr);
+
     // TODO: This is terrible ... I should be able to make a single function to do this?
     void holdCard1(bool cardHeld);
     void holdCard2(bool cardHeld);
@@ -64,7 +67,7 @@ private:
     Account          &_playerCredits;
     GameOrchestrator *_gameOrc;
     JacksOrBetter    *_gameLogic;
-    QThread          *_gameEventProcessor;     // TODO: Figure out threading for worker process
+    QThread          *_gameEventProcessor;
     Ui::GameOrchestratorWindow *ui;
 };
 

--- a/src/ui/gameorchestratorwindow.ui
+++ b/src/ui/gameorchestratorwindow.ui
@@ -49,7 +49,7 @@ color: rgb(255, 255, 255);</string>
              <item>
               <widget class="QLabel" name="label">
                <property name="text">
-                <string>Work-in-progress -- Multiple Hand display area still to do</string>
+                <string>(placeholder label)</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignCenter</set>
@@ -279,7 +279,7 @@ font-size: 20pt;</string>
        <item>
         <widget class="QPushButton" name="speedButton">
          <property name="text">
-          <string>Speed (M)</string>
+          <string>Speed &gt;&gt;&gt;&gt; (M)</string>
          </property>
          <property name="shortcut">
           <string>M</string>

--- a/src/ui/handwidget.cpp
+++ b/src/ui/handwidget.cpp
@@ -54,7 +54,7 @@ void HandWidget::winningTextAndAmount(const QString &handString, quint32 winning
     } else if (winning == 0) {
         ui->resultLabel->setText(handString);
     } else {
-        ui->resultLabel->setText(handString + " + " + QString::number(winning));
+        ui->resultLabel->setText(handString + " - Win +" + QString::number(winning));
     }
 }
 
@@ -162,6 +162,30 @@ void HandWidget::revealCard(int cardIdx, PlayingCard card)
     default:
         // Should not happen!
         break;
+    }
+}
+
+void HandWidget::showCardBacks(bool card1, bool card2, bool card3, bool card4, bool card5)
+{
+    if (card1) {
+        ui->card1->setText("Chad's\nCasino");
+        ui->card1->setStyleSheet(cardBackStyle);
+    }
+    if (card2) {
+        ui->card2->setText("Chad's\nCasino");
+        ui->card2->setStyleSheet(cardBackStyle);
+    }
+    if (card3) {
+        ui->card3->setText("Chad's\nCasino");
+        ui->card3->setStyleSheet(cardBackStyle);
+    }
+    if (card4) {
+        ui->card4->setText("Chad's\nCasino");
+        ui->card4->setStyleSheet(cardBackStyle);
+    }
+    if (card5) {
+        ui->card5->setText("Chad's\nCasino");
+        ui->card5->setStyleSheet(cardBackStyle);
     }
 }
 

--- a/src/ui/handwidget.h
+++ b/src/ui/handwidget.h
@@ -44,6 +44,9 @@ public slots:
     // Update a drawn card in its relevant position
     void revealCard(int cardIdx, PlayingCard card);
 
+    // Hide cards (flip them back over) that are about to be redrawn
+    void showCardBacks(bool card1, bool card2, bool card3, bool card4, bool card5);
+
     // Flip all cards back around and reset the hold checkboxes
     void resetAll();
 
@@ -58,6 +61,7 @@ signals:
     void card5Hold(bool cardIsHeld);
 
 private:
+    // Actual Qt widgets
     Ui::HandWidget *ui;
 };
 

--- a/src/ui/handwidget.ui
+++ b/src/ui/handwidget.ui
@@ -13,24 +13,27 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <property name="styleSheet">
+   <string notr="true">QCheckBox:checked {color: rgb(125,30,0); background-color: rgb(250,250,0);}</string>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0">
    <item>
     <widget class="QFrame" name="cardArea">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <layout class="QHBoxLayout" name="cardLayoutItem">
       <item>
        <widget class="QLabel" name="card1">
-        <property name="sizeIncrement">
-         <size>
-          <width>25</width>
-          <height>35</height>
-         </size>
-        </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(0, 0, 0);
@@ -57,12 +60,6 @@ Casino</string>
       </item>
       <item>
        <widget class="QLabel" name="card2">
-        <property name="sizeIncrement">
-         <size>
-          <width>25</width>
-          <height>35</height>
-         </size>
-        </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(0, 0, 0);
@@ -89,12 +86,6 @@ Casino</string>
       </item>
       <item>
        <widget class="QLabel" name="card3">
-        <property name="sizeIncrement">
-         <size>
-          <width>25</width>
-          <height>35</height>
-         </size>
-        </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(0, 0, 0);
@@ -121,12 +112,6 @@ Casino</string>
       </item>
       <item>
        <widget class="QLabel" name="card4">
-        <property name="sizeIncrement">
-         <size>
-          <width>25</width>
-          <height>35</height>
-         </size>
-        </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(0, 0, 0);
@@ -153,12 +138,6 @@ Casino</string>
       </item>
       <item>
        <widget class="QLabel" name="card5">
-        <property name="sizeIncrement">
-         <size>
-          <width>25</width>
-          <height>35</height>
-         </size>
-        </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(0, 0, 0);

--- a/test/jacksorbetter_orctest.cpp
+++ b/test/jacksorbetter_orctest.cpp
@@ -36,7 +36,7 @@ void initAndPlayOneRound(const QVector<bool> &cardsToHold, Hand &firstHand, Hand
     playerAcct.add(1000);
 
     JacksOrBetter    gameJOB;
-    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct);
+    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct, 0);
 
     // Deal the cards from the internal random deck
     orcJOB.dealDraw();
@@ -114,7 +114,7 @@ void JacksOrBetter_OrcTest::testSingleHandMultipleGames()
     playerAcct.add(1000);
 
     JacksOrBetter    gameJOB;
-    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct);
+    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct, 0);
 
     // Deal the cards from the internal random deck
     orcJOB.dealDraw();
@@ -174,7 +174,7 @@ void JacksOrBetter_OrcTest::testSingleHandInsufficientFunds()
     Account playerAcct;
     playerAcct.add(2);
     JacksOrBetter gameJOB;
-    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct);
+    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct, 0);
     orcJOB.setCreditsToBet(5);
     orcJOB.dealDraw();
     Hand emptyHand;
@@ -196,7 +196,7 @@ void JacksOrBetter_OrcTest::testBetCycling()
     Account playerAcct;
     playerAcct.add(100);
     JacksOrBetter gameJOB;
-    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct);
+    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct, 0);
 
     // Any PokerGame sub-class initialization (JacksOrBetter in this case) will be for credits-per-bet of 1
     QCOMPARE(orcJOB.creditsToBet(), 1);
@@ -219,7 +219,7 @@ void JacksOrBetter_OrcTest::testBetMaximum()
     Account playerAcct;
     playerAcct.add(100);
     JacksOrBetter gameJOB;
-    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct);
+    GameOrchestrator orcJOB(&gameJOB, 1, playerAcct, 0);
 
     // Any PokerGame sub-class initialization (JacksOrBetter in this case) will be for credits-per-bet of 1
     QCOMPARE(orcJOB.creditsToBet(), 1);


### PR DESCRIPTION
Pushes the generic game orchestrator to its own thread (does not run with the UI). This allows for running the card rendering at different speeds without messing up the UI, like an actual terminal. Special care was taken to ensure the thread and orchestrator are correctly stopped and cleaned up when the game window is closed ... hopefully it works (I tried it several times and did not see any long term memory leaking).