### PR TITLE
Fix Aspect Ratios + Better Threading

### DIFF
--- a/src/poker/gameorchestrator.cpp
+++ b/src/poker/gameorchestrator.cpp
@@ -89,6 +89,11 @@ void GameOrchestrator::currentPayTable(QVector<QPair<const QString, int> > &payT
     _gameAnalyzer->currentPayTable(payTable);
 }
 
+bool GameOrchestrator::isGameInProgress() const
+{
+    return _handInProg;
+}
+
 void GameOrchestrator::dealDraw()
 {
     if (!_handInProg) {

--- a/src/poker/gameorchestrator.h
+++ b/src/poker/gameorchestrator.h
@@ -98,6 +98,13 @@ public:
      */
     void currentPayTable(QVector<QPair<const QString, int>> &payTable);
 
+    /**
+     * @brief isGameInProgress determines if the orchestrator is waiting for the use to hold cards and redraw
+     *
+     * @return true if there is a hand / game in progress
+     */
+    bool isGameInProgress() const;
+
 public slots:
     /**
      * @brief dealDraw will deal 5 cards per _gameCard pair when called the first time. When called the second time, it

--- a/src/ui/gameorchestratorwindow.h
+++ b/src/ui/gameorchestratorwindow.h
@@ -40,12 +40,19 @@ public:
     explicit GameOrchestratorWindow(Account &playerAccount, QWidget *parent = nullptr);
     ~GameOrchestratorWindow();
 
+    // For custom resize handling of widgets
+    void resizeEvent(QResizeEvent* event);
+    void fixPayoutTableSize();
+
 public slots:
     // Paytable updates when the betting is changed
     void showPayTableAndBet();
 
     // set showDraw to true so the button for deal/draw only says "Draw", otherwise it is "Deal"
     void dealToDraw(bool showDraw);
+
+    // Resets the cards BEFORE calling the dealDraw of the orchestrator (prevents exceptions/collisions between threads)
+    void syncDealDraw();
 
     // Update winnings as hand(s) processed by the orchestrator
     void currentWinnings(quint32 winningsOfHands);
@@ -62,6 +69,14 @@ public slots:
     void holdCard3(bool cardHeld);
     void holdCard4(bool cardHeld);
     void holdCard5(bool cardHeld);
+
+signals:
+    // Should be emitted before calling the dealDraw to give the UI time to catch up before the orchestrator delivers
+    // any new cards
+    void resetCardDisplay();
+
+    // Emitted when the window is ready for the orchestrator to deliver cards
+    void readyForDealDraw();
 
 private:
     Account          &_playerCredits;

--- a/src/ui/gameorchestratorwindow.ui
+++ b/src/ui/gameorchestratorwindow.ui
@@ -6,32 +6,38 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1467</width>
-    <height>695</height>
+    <width>1388</width>
+    <height>660</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>VidPokerTerminal</string>
   </property>
+  <property name="styleSheet">
+   <string notr="true">background-color: rgb(6, 139, 3);
+color: rgb(255, 255, 255);</string>
+  </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
     <item>
      <widget class="QFrame" name="handTableCreditsArea">
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
       <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
+       <enum>QFrame::NoFrame</enum>
       </property>
       <property name="frameShadow">
        <enum>QFrame::Raised</enum>
       </property>
-      <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
+      <layout class="QHBoxLayout" name="horizontalLayout" stretch="7,3">
        <item>
         <widget class="QFrame" name="handArea">
          <property name="styleSheet">
-          <string notr="true">background-color: rgb(6, 139, 3);
-color: rgb(255, 255, 255);</string>
+          <string notr="true"/>
          </property>
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
+          <enum>QFrame::NoFrame</enum>
          </property>
          <property name="frameShadow">
           <enum>QFrame::Raised</enum>
@@ -40,29 +46,18 @@ color: rgb(255, 255, 255);</string>
           <item>
            <widget class="QFrame" name="multipleHand">
             <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="frameShadow">
              <enum>QFrame::Raised</enum>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_3">
-             <item>
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>(placeholder label)</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <layout class="QVBoxLayout" name="verticalLayout_3"/>
            </widget>
           </item>
           <item>
            <widget class="QFrame" name="primaryHand">
             <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="frameShadow">
              <enum>QFrame::Raised</enum>
@@ -76,7 +71,7 @@ color: rgb(255, 255, 255);</string>
        <item>
         <widget class="QFrame" name="payTableArea">
          <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
+          <enum>QFrame::NoFrame</enum>
          </property>
          <property name="frameShadow">
           <enum>QFrame::Raised</enum>
@@ -84,8 +79,11 @@ color: rgb(255, 255, 255);</string>
          <layout class="QVBoxLayout" name="verticalLayout_5">
           <item>
            <widget class="QFrame" name="payoutTable">
+            <property name="styleSheet">
+             <string notr="true">font-size: 18pt;</string>
+            </property>
             <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="frameShadow">
              <enum>QFrame::Raised</enum>
@@ -102,6 +100,15 @@ color: rgb(255, 255, 255);</string>
               <widget class="QTableWidget" name="payoutDisplay">
                <property name="focusPolicy">
                 <enum>Qt::NoFocus</enum>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">font-size: 16pt;</string>
+               </property>
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <property name="horizontalScrollBarPolicy">
+                <enum>Qt::ScrollBarAlwaysOff</enum>
                </property>
                <property name="sizeAdjustPolicy">
                 <enum>QAbstractScrollArea::AdjustToContents</enum>
@@ -138,22 +145,17 @@ color: rgb(255, 255, 255);</string>
           </item>
           <item>
            <widget class="QFrame" name="accountBets">
-            <property name="styleSheet">
-             <string notr="true">background-color: rgb(0, 0, 0);
-color: rgb(255, 255, 255);</string>
-            </property>
             <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
+             <enum>QFrame::NoFrame</enum>
             </property>
             <property name="frameShadow">
              <enum>QFrame::Raised</enum>
             </property>
-            <layout class="QGridLayout" name="gridLayout">
+            <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
              <item row="0" column="0">
               <widget class="QLabel" name="winLabel">
                <property name="styleSheet">
-                <string notr="true">color: rgb(255, 0, 0);
-font-size: 20pt;</string>
+                <string notr="true">font-size: 20pt;</string>
                </property>
                <property name="text">
                 <string>Win</string>
@@ -166,7 +168,7 @@ font-size: 20pt;</string>
              <item row="0" column="1">
               <widget class="QLCDNumber" name="winAmount">
                <property name="styleSheet">
-                <string notr="true">color: rgb(255, 0, 0);</string>
+                <string notr="true">font-size: 20pt;</string>
                </property>
                <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
@@ -175,7 +177,7 @@ font-size: 20pt;</string>
                 <enum>QFrame::Plain</enum>
                </property>
                <property name="digitCount">
-                <number>10</number>
+                <number>11</number>
                </property>
                <property name="segmentStyle">
                 <enum>QLCDNumber::Flat</enum>
@@ -185,8 +187,7 @@ font-size: 20pt;</string>
              <item row="1" column="0">
               <widget class="QLabel" name="betLabel">
                <property name="styleSheet">
-                <string notr="true">color: rgb(0, 255, 255);
-font-size: 20pt;</string>
+                <string notr="true">font-size: 20pt;</string>
                </property>
                <property name="text">
                 <string>Bet</string>
@@ -198,9 +199,6 @@ font-size: 20pt;</string>
              </item>
              <item row="1" column="1">
               <widget class="QLCDNumber" name="betAmount">
-               <property name="styleSheet">
-                <string notr="true">color: rgb(0, 255, 255);</string>
-               </property>
                <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
                </property>
@@ -208,7 +206,7 @@ font-size: 20pt;</string>
                 <enum>QFrame::Plain</enum>
                </property>
                <property name="digitCount">
-                <number>10</number>
+                <number>11</number>
                </property>
                <property name="segmentStyle">
                 <enum>QLCDNumber::Flat</enum>
@@ -218,8 +216,7 @@ font-size: 20pt;</string>
              <item row="2" column="0">
               <widget class="QLabel" name="creditsLabel">
                <property name="styleSheet">
-                <string notr="true">color: rgb(0, 255, 0);
-font-size: 20pt;</string>
+                <string notr="true">font-size: 20pt;</string>
                </property>
                <property name="text">
                 <string>Credits</string>
@@ -231,9 +228,6 @@ font-size: 20pt;</string>
              </item>
              <item row="2" column="1">
               <widget class="QLCDNumber" name="creditsAmount">
-               <property name="styleSheet">
-                <string notr="true">color: rgb(0, 255, 0);</string>
-               </property>
                <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
                </property>
@@ -241,7 +235,7 @@ font-size: 20pt;</string>
                 <enum>QFrame::Plain</enum>
                </property>
                <property name="digitCount">
-                <number>10</number>
+                <number>11</number>
                </property>
                <property name="segmentStyle">
                 <enum>QLCDNumber::Flat</enum>
@@ -259,8 +253,11 @@ font-size: 20pt;</string>
     </item>
     <item>
      <widget class="QFrame" name="softKeyArea">
+      <property name="styleSheet">
+       <string notr="true">background-color: rgb(0, 0, 0);</string>
+      </property>
       <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
+       <enum>QFrame::NoFrame</enum>
       </property>
       <property name="frameShadow">
        <enum>QFrame::Raised</enum>
@@ -268,8 +265,35 @@ font-size: 20pt;</string>
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <widget class="QPushButton" name="returnButton">
+         <property name="styleSheet">
+          <string notr="true">QPushButton:disabled {
+    color: black;
+    background-color: gray;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    color: black;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:pressed {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+         </property>
          <property name="text">
-          <string>Return (Esc)</string>
+          <string>Return</string>
          </property>
          <property name="shortcut">
           <string>Esc</string>
@@ -278,8 +302,35 @@ font-size: 20pt;</string>
        </item>
        <item>
         <widget class="QPushButton" name="speedButton">
+         <property name="styleSheet">
+          <string notr="true">QPushButton:disabled {
+    color: black;
+    background-color: gray;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    color: black;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:pressed {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+         </property>
          <property name="text">
-          <string>Speed &gt;&gt;&gt;&gt; (M)</string>
+          <string>Speed &gt;&gt;&gt;&gt;</string>
          </property>
          <property name="shortcut">
           <string>M</string>
@@ -288,8 +339,35 @@ font-size: 20pt;</string>
        </item>
        <item>
         <widget class="QPushButton" name="betIncrementButton">
+         <property name="styleSheet">
+          <string notr="true">QPushButton:disabled {
+    color: black;
+    background-color: gray;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    color: black;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:pressed {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+         </property>
          <property name="text">
-          <string>Increase Bet (,)</string>
+          <string>Increase Bet</string>
          </property>
          <property name="shortcut">
           <string>,</string>
@@ -298,8 +376,35 @@ font-size: 20pt;</string>
        </item>
        <item>
         <widget class="QPushButton" name="maxBetButton">
+         <property name="styleSheet">
+          <string notr="true">QPushButton:disabled {
+    color: black;
+    background-color: gray;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    color: black;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:pressed {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+         </property>
          <property name="text">
-          <string>Bet Maximum (.)</string>
+          <string>Bet Maximum</string>
          </property>
          <property name="shortcut">
           <string>.</string>
@@ -308,8 +413,35 @@ font-size: 20pt;</string>
        </item>
        <item>
         <widget class="QPushButton" name="drawDealButton">
+         <property name="styleSheet">
+          <string notr="true">QPushButton:disabled {
+    color: black;
+    background-color: gray;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    color: black;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:pressed {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+         </property>
          <property name="text">
-          <string>Deal (/)</string>
+          <string>Deal</string>
          </property>
          <property name="shortcut">
           <string>/</string>

--- a/src/ui/handwidget.cpp
+++ b/src/ui/handwidget.cpp
@@ -30,16 +30,11 @@ HandWidget::HandWidget(QWidget *parent) :
 
     // There are 5 cards, selecting their respective hold buttons should indicate to the game orchestrator they are
     // to be preserved and not re-drawn
-    connect(ui->holdBtnCard1, &QCheckBox::toggled,
-            this, &HandWidget::card1Hold);
-    connect(ui->holdBtnCard2, &QCheckBox::toggled,
-            this, &HandWidget::card2Hold);
-    connect(ui->holdBtnCard3, &QCheckBox::toggled,
-            this, &HandWidget::card3Hold);
-    connect(ui->holdBtnCard4, &QCheckBox::toggled,
-            this, &HandWidget::card4Hold);
-    connect(ui->holdBtnCard5, &QCheckBox::toggled,
-            this, &HandWidget::card5Hold);
+    connect(ui->holdBtnCard1, &QPushButton::toggled, this, &HandWidget::card1Hold);
+    connect(ui->holdBtnCard2, &QPushButton::toggled, this, &HandWidget::card2Hold);
+    connect(ui->holdBtnCard3, &QPushButton::toggled, this, &HandWidget::card3Hold);
+    connect(ui->holdBtnCard4, &QPushButton::toggled, this, &HandWidget::card4Hold);
+    connect(ui->holdBtnCard5, &QPushButton::toggled, this, &HandWidget::card5Hold);
 }
 
 HandWidget::~HandWidget()
@@ -50,7 +45,7 @@ HandWidget::~HandWidget()
 void HandWidget::winningTextAndAmount(const QString &handString, quint32 winning)
 {
     if (handString.isEmpty()) {
-        ui->resultLabel->setText("");    // Nothing, no winning combination
+        ui->resultLabel->setText("");
     } else if (winning == 0) {
         ui->resultLabel->setText(handString);
     } else {
@@ -192,11 +187,11 @@ void HandWidget::showCardBacks(bool card1, bool card2, bool card3, bool card4, b
 void HandWidget::resetAll()
 {
     // Unset holds
-    ui->holdBtnCard1->setCheckState(Qt::Unchecked);
-    ui->holdBtnCard2->setCheckState(Qt::Unchecked);
-    ui->holdBtnCard3->setCheckState(Qt::Unchecked);
-    ui->holdBtnCard4->setCheckState(Qt::Unchecked);
-    ui->holdBtnCard5->setCheckState(Qt::Unchecked);
+    ui->holdBtnCard1->setChecked(false);
+    ui->holdBtnCard2->setChecked(false);
+    ui->holdBtnCard3->setChecked(false);
+    ui->holdBtnCard4->setChecked(false);
+    ui->holdBtnCard5->setChecked(false);
 
     // Flip cards back
     ui->card1->setText("Chad's\nCasino");
@@ -209,6 +204,9 @@ void HandWidget::resetAll()
     ui->card4->setStyleSheet(cardBackStyle);
     ui->card5->setText("Chad's\nCasino");
     ui->card5->setStyleSheet(cardBackStyle);
+
+    // Hide any winning string
+    ui->resultLabel->setText("");
 }
 
 void HandWidget::enableHolds(bool enableCheckBoxes)

--- a/src/ui/handwidget.ui
+++ b/src/ui/handwidget.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>795</width>
-    <height>299</height>
+    <width>960</width>
+    <height>376</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Form</string>
@@ -16,102 +22,30 @@
   <property name="styleSheet">
    <string notr="true">QCheckBox:checked {color: rgb(125,30,0); background-color: rgb(250,250,0);}</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0">
    <item>
     <widget class="QFrame" name="cardArea">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QHBoxLayout" name="cardLayoutItem">
-      <item>
-       <widget class="QLabel" name="card1">
-        <property name="styleSheet">
-         <string notr="true">background-color: rgb(0, 66, 188);
-border-color: rgb(0, 0, 0);
-color: rgb(227, 227, 227);
-font-size: 20pt;</string>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <property name="lineWidth">
-         <number>4</number>
-        </property>
-        <property name="text">
-         <string>Chad's
-Casino</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="card2">
-        <property name="styleSheet">
-         <string notr="true">background-color: rgb(0, 66, 188);
-border-color: rgb(0, 0, 0);
-color: rgb(227, 227, 227);
-font-size: 20pt;</string>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <property name="lineWidth">
-         <number>4</number>
-        </property>
-        <property name="text">
-         <string>Chad's
-Casino</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="card3">
-        <property name="styleSheet">
-         <string notr="true">background-color: rgb(0, 66, 188);
-border-color: rgb(0, 0, 0);
-color: rgb(227, 227, 227);
-font-size: 20pt;</string>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <property name="lineWidth">
-         <number>4</number>
-        </property>
-        <property name="text">
-         <string>Chad's
-Casino</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item>
+     <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,0,0,0,0,1">
+      <item row="0" column="4">
        <widget class="QLabel" name="card4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>180</width>
+          <height>250</height>
+         </size>
+        </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(0, 0, 0);
@@ -136,8 +70,58 @@ Casino</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="card3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>180</width>
+          <height>250</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">background-color: rgb(0, 66, 188);
+border-color: rgb(0, 0, 0);
+color: rgb(227, 227, 227);
+font-size: 20pt;</string>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>4</number>
+        </property>
+        <property name="text">
+         <string>Chad's
+Casino</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
        <widget class="QLabel" name="card5">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>180</width>
+          <height>250</height>
+         </size>
+        </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(0, 0, 0);
@@ -162,86 +146,110 @@ Casino</string>
         </property>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QFrame" name="holdArea">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QCheckBox" name="holdBtnCard1">
+      <item row="1" column="0">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="card1">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>180</width>
+          <height>250</height>
+         </size>
+        </property>
         <property name="styleSheet">
-         <string notr="true">font-size: 14pt;</string>
+         <string notr="true">background-color: rgb(0, 66, 188);
+border-color: rgb(0, 0, 0);
+color: rgb(227, 227, 227);
+font-size: 20pt;</string>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>4</number>
         </property>
         <property name="text">
-         <string>Hold (1)</string>
+         <string>Chad's
+Casino</string>
         </property>
-        <property name="shortcut">
-         <string>1</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QCheckBox" name="holdBtnCard2">
+      <item row="0" column="2">
+       <widget class="QLabel" name="card2">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>180</width>
+          <height>250</height>
+         </size>
+        </property>
         <property name="styleSheet">
-         <string notr="true">font-size: 14pt;</string>
+         <string notr="true">background-color: rgb(0, 66, 188);
+border-color: rgb(0, 0, 0);
+color: rgb(227, 227, 227);
+font-size: 20pt;</string>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>4</number>
         </property>
         <property name="text">
-         <string>Hold (2)</string>
+         <string>Chad's
+Casino</string>
         </property>
-        <property name="shortcut">
-         <string>2</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QCheckBox" name="holdBtnCard3">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+      <item row="1" column="6">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
-        <property name="styleSheet">
-         <string notr="true">font-size: 14pt;</string>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
         </property>
-        <property name="text">
-         <string>Hold (3)</string>
-        </property>
-        <property name="shortcut">
-         <string>3</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
+       </spacer>
       </item>
-      <item>
-       <widget class="QCheckBox" name="holdBtnCard4">
+      <item row="1" column="5">
+       <widget class="QPushButton" name="holdBtnCard5">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -249,29 +257,28 @@ Casino</string>
          </sizepolicy>
         </property>
         <property name="styleSheet">
-         <string notr="true">font-size: 14pt;</string>
-        </property>
-        <property name="text">
-         <string>Hold (4)</string>
-        </property>
-        <property name="shortcut">
-         <string>4</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="holdBtnCard5">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">font-size: 14pt;</string>
+         <string notr="true">QPushButton:disabled {
+    color: gray;
+    border-style: flat;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:checked {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
         </property>
         <property name="text">
          <string>Hold (5)</string>
@@ -284,16 +291,194 @@ Casino</string>
         </property>
        </widget>
       </item>
+      <item row="1" column="4">
+       <widget class="QPushButton" name="holdBtnCard4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QPushButton:disabled {
+    color: gray;
+    border-style: flat;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:checked {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+        </property>
+        <property name="text">
+         <string>Hold (4)</string>
+        </property>
+        <property name="shortcut">
+         <string>4</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QPushButton" name="holdBtnCard3">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QPushButton:disabled {
+    color: gray;
+    border-style: flat;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:checked {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+        </property>
+        <property name="text">
+         <string>Hold (3)</string>
+        </property>
+        <property name="shortcut">
+         <string>3</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="holdBtnCard2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QPushButton:disabled {
+    color: gray;
+    border-style: flat;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:checked {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+        </property>
+        <property name="text">
+         <string>Hold (2)</string>
+        </property>
+        <property name="shortcut">
+         <string>2</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="holdBtnCard1">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QPushButton:disabled {
+    color: gray;
+    border-style: flat;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:checked {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+        </property>
+        <property name="text">
+         <string>Hold (1)</string>
+        </property>
+        <property name="shortcut">
+         <string>1</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
    <item>
     <widget class="QLabel" name="resultLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="styleSheet">
       <string notr="true">font-size: 18pt;</string>
      </property>
      <property name="text">
-      <string>Select betting level, then press 'Deal' to begin a game</string>
+      <string>Select bet level, then press 'Deal' to begin a game</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>


### PR DESCRIPTION
UI Layout Fixes:
- Made whole UI card-game-table-green
- Reskinned UI softkeys and hold buttons in the GameOrchestratorWindow
- Hand widget now keeps everything fixed in a grid. Expanding spacers to the left and right ensure no weird stretching of the cards themselves.

Remaining UI issues:
- Everything is pretty resolution dependent feeling for now. Not sure how to make this better, but ideally we will want to support several DPIs and screen resolutions: full 1080p ~15inch monitor game screens vs. smallish handheld device?
- Pay-table needs to take up the right amount of space when the GameOrchestratorWindow is spawned (for now, it only takes up the "right" amount of space when resizing the window)
- The game picker / main window is still a mess and will be fixed soon.
- The individual game logics should be chosen from the main window / game picker and forwarded? For now the code is not very generic.

Thread / Synchro Issues:
Discovered on the Raspberry Pi Zero. With it's slower single core design, a race condition was noticed when resetting a hand for a new game. Cards would reset at the same time as new cards were being filled into hands. This lead to hand-not-complete exceptions and a really jittery appearance when dealing the first round of cards in a game.
The fix was to put extra logic on the GameOrchestratorWindow which then checked the game status and reset the cards on the UI thread BEFORE emitting a deal signal to the orchestrator thread.