### PR TITLE
Finish Jacks or Better Algorithm

### DIFF
--- a/src/poker/commonhandanalysis.cpp
+++ b/src/poker/commonhandanalysis.cpp
@@ -34,7 +34,7 @@ void sortHandVector(QVector<PlayingCard> &hand)
     });
 }
 
-quint8 NOfAKind(quint8 nValue, const QVector<PlayingCard> &hand)
+quint8 NOfAKind(quint8 nValue, const QVector<PlayingCard> &hand, QVector<PlayingCard::CardValue> &matches)
 {
     // Map to associate count of all cards in a hand
     QMap<PlayingCard::CardValue, quint8> cardValueCounts;
@@ -49,6 +49,7 @@ quint8 NOfAKind(quint8 nValue, const QVector<PlayingCard> &hand)
     for (const PlayingCard::CardValue &cardVal : cardValueCounts.keys()) {
         if (cardValueCounts[cardVal] == nValue) {
             ++nbNValuesFound;
+            matches.push_back(cardVal);
         }
     }
     return nbNValuesFound;
@@ -60,31 +61,46 @@ quint8 NOfAKind(quint8 nValue, const QVector<PlayingCard> &hand)
  */
 bool JacksOrBetter(const QVector<PlayingCard> &hand)
 {
-    bool JOB = false;
+    QVector<PlayingCard::CardValue> matches;
+    NOfAKind(2, hand, matches);
 
-    // TODO: Insert Jacks-Or-Better code
-
-    return JOB;
+    // See if the matched pair was J+J, Q+Q, K+K, A+A
+    for (const PlayingCard::CardValue &value : matches) {
+        if (value == PlayingCard::ACE   || value == PlayingCard::KING ||
+            value == PlayingCard::QUEEN || value == PlayingCard::JACK)
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool TwoPair(const QVector<PlayingCard> &hand)
 {
-    // No card value occurred 4 times in the hand
-    return (NOfAKind(2, hand) == 2);
+    QVector<PlayingCard::CardValue> matches;       // Unused for Three of a Kind
+    return (NOfAKind(2, hand, matches) == 2);
 }
 
 bool ThreeOfAKind(const QVector<PlayingCard> &hand)
 {
-    return (NOfAKind(3, hand) == 1);
+    QVector<PlayingCard::CardValue> matches;       // Unused for Three of a Kind
+    return (NOfAKind(3, hand, matches) == 1);
 }
 
 bool Straight(const QVector<PlayingCard> &hand)
 {
-    bool STR = false;
+    PlayingCard::CardValue lowestCard = hand[0].value();
 
-    // TODO: Insert code to find a straight here
+    for (qint32 handIdx = 1; handIdx < hand.size(); ++handIdx) {
+        if (hand[handIdx].value() == lowestCard + 1) {
+            lowestCard = hand[handIdx].value();
+        } else {
+            return false;
+        }
+    }
 
-    return STR;
+    // If control got out of the loop, then each card must have been higher than the last
+    return true;
 }
 
 bool Flush(const QVector<PlayingCard> &hand)
@@ -100,12 +116,14 @@ bool Flush(const QVector<PlayingCard> &hand)
 
 bool FullHouse(const QVector<PlayingCard> &hand)
 {
-    return (NOfAKind(3, hand) == 1 && NOfAKind(2, hand) == 1);
+    QVector<PlayingCard::CardValue> matches;    // Unused for Full House
+    return (NOfAKind(3, hand, matches) == 1 && NOfAKind(2, hand, matches) == 1);
 }
 
 bool FourOfAKind(const QVector<PlayingCard> &hand)
 {
-    return (NOfAKind(4, hand) == 1);
+    QVector<PlayingCard::CardValue> matches;    // Unused for Full House
+    return (NOfAKind(4, hand, matches) == 1);
 }
 
 bool StraightFlush(const QVector<PlayingCard> &hand)

--- a/src/poker/commonhandanalysis.cpp
+++ b/src/poker/commonhandanalysis.cpp
@@ -89,6 +89,17 @@ bool ThreeOfAKind(const QVector<PlayingCard> &hand)
 
 bool Straight(const QVector<PlayingCard> &hand)
 {
+    // Must handle Ace-Considered-Low-Card variety of straight (can only be A-2-3-4-5), but the sorter will have left
+    // the cards as 2-3-4-5-A
+    if (hand[0].value() == PlayingCard::TWO &&
+        hand[1].value() == PlayingCard::THREE &&
+        hand[2].value() == PlayingCard::FOUR &&
+        hand[3].value() == PlayingCard::FIVE &&
+        hand[4].value() == PlayingCard::ACE) {
+        return true;
+    }
+
+    // Ace-Considered-High-Card variety of straight -- relies on intrinsic PlayingCard::Value ordering
     PlayingCard::CardValue lowestCard = hand[0].value();
 
     for (qint32 handIdx = 1; handIdx < hand.size(); ++handIdx) {

--- a/src/poker/commonhandanalysis.h
+++ b/src/poker/commonhandanalysis.h
@@ -38,12 +38,13 @@ void sortHandVector(QVector<PlayingCard> &hand);
  *
  * @param[in]  nValue    The value of "N" in "N"-of-a-kind
  * @param[in]  hand      A single hand of a poker game
+ * @param[out] matches   Vector of card values that were matched nValue times
  *
  * @return     number of times "N" of a kind was found in the hand
  *                 EXAMPLES: To match "Two Pair":         NOfAKind(2, hand) ==> 2
  *                           To match "Three of a Kind":  NOfAKind(3, hand) ==> 1
  */
-quint8 NOfAKind(quint8 nValue, const QVector<PlayingCard> &hand);
+quint8 NOfAKind(quint8 nValue, const QVector<PlayingCard> &hand, QVector<PlayingCard::CardValue> &matches);
 
 /**
  * @brief      Determines if a hand meets Jacks-or-Better criteria

--- a/test/pokerhand_test.cpp
+++ b/test/pokerhand_test.cpp
@@ -296,7 +296,7 @@ void TestHands::testJOB_StraightAceLow()
     Hand stAceFive(PlayingCard(PlayingCard::SPADE,   PlayingCard::FIVE ),
                    PlayingCard(PlayingCard::DIAMOND, PlayingCard::THREE),
                    PlayingCard(PlayingCard::HEART,   PlayingCard::TWO  ),
-                   PlayingCard(PlayingCard::CLUB,    PlayingCard::FIVE ),
+                   PlayingCard(PlayingCard::CLUB,    PlayingCard::FOUR ),
                    PlayingCard(PlayingCard::CLUB,    PlayingCard::ACE  ));
     validateResult(JOB, stAceFive, 1,  4, "Straight");
 }

--- a/test/pokerhand_test.cpp
+++ b/test/pokerhand_test.cpp
@@ -402,5 +402,14 @@ void TestHands::testJOB_NoWin()
                         PlayingCard(PlayingCard::SPADE,   PlayingCard::SIX  ),
                         PlayingCard(PlayingCard::DIAMOND, PlayingCard::FIVE )),
                    1, 0, "");
+
+    // Almost a straight flush, but not quite!
+    validateResult(JOB,
+                   Hand(PlayingCard(PlayingCard::DIAMOND, PlayingCard::NINE ),
+                        PlayingCard(PlayingCard::DIAMOND, PlayingCard::EIGHT),
+                        PlayingCard(PlayingCard::DIAMOND, PlayingCard::SIX  ),
+                        PlayingCard(PlayingCard::SPADE,   PlayingCard::SIX  ),
+                        PlayingCard(PlayingCard::DIAMOND, PlayingCard::FIVE )),
+                   1, 0, "");
     // TODO: how many tests does it make sense to do for "no win" hands?
 }


### PR DESCRIPTION
This contains all the completed hand analysis to accomplish Jacks-or-Better determinations.
The NOfAKind function was enhanced to return a QVector of card values that matched NOfAKind, so we can check, for instance, that NOfAKind(2, hand, matches); will have "matches" (a QVector) containing J/Q/K/A and not lower cards.
Logic for a Straight was also done, relying on the intrinsic sorting of the PlayingCard::Value enumerated type. This doesn't work for an Ace-Low-Straight (A-2-3-4-5), so a specific exception was put in for that as there is only one of those possible.