### PR TITLE
Account and Game Launch Parameters Window Implementation

### DIFF
--- a/src/poker/account.cpp
+++ b/src/poker/account.cpp
@@ -17,7 +17,7 @@
 
 #include "account.h"
 
-Account::Account() : _balance(0)
+Account::Account(QObject *parent) : QObject(parent), _balance(0)
 {
 
 }
@@ -30,6 +30,7 @@ quint32 Account::balance() const
 void Account::setBalance(quint32 newBal)
 {
     _balance = newBal;
+    emit balanceChanged(_balance);
 }
 
 bool Account::withdraw(quint32 amount)
@@ -38,10 +39,12 @@ bool Account::withdraw(quint32 amount)
         return false;
     }
     _balance -= amount;
+    emit balanceChanged(_balance);
     return true;
 }
 
 void Account::add(quint32 amount)
 {
     _balance += amount;
+    emit balanceChanged(_balance);
 }

--- a/src/poker/account.h
+++ b/src/poker/account.h
@@ -18,18 +18,19 @@
 #ifndef ACCOUNT_H
 #define ACCOUNT_H
 
-#include <qglobal.h>
+#include <QObject>
 
 /**
  * @brief The Account class handles adding/withdrawing/checking the balance of credits available for betting
  */
-class Account
+class Account : public QObject
 {
+    Q_OBJECT
 public:
     /**
      * @brief Sets up an empty account
      */
-    explicit Account();
+    explicit Account(QObject *parent = nullptr);
 
     /**
      * @brief balance retrieves the number of credits available to bet
@@ -39,13 +40,7 @@ public:
     quint32 balance() const;
 
     /**
-     * @brief setBalance forces a new value to be held by the account
-     *
-     * @param[in]  newBal     Exact number of credits to save into the account
-     */
-    void setBalance(quint32 newBal);
 
-    /**
      * @brief withdraw will try and pull credits out of the account to use for a bet
      *
      * @param[in]  amount     Number of credits to take out of the account
@@ -54,12 +49,26 @@ public:
      */
     bool withdraw(quint32 amount);
 
+signals:
+
+    // Emitted whenever the balance changes
+    void balanceChanged(quint32 updatedBalance);
+
+public slots:
+    /**
+     * @brief setBalance forces a new value to be held by the account
+     *
+     * @param[in]  newBal     Exact number of credits to save into the account
+     */
+    void setBalance(quint32 newBal);
+
     /**
      * @brief add
      *
      * @param[in]  amount     Number of credits to add to the account
      */
     void add(quint32 amount);
+
 private:
     quint32 _balance;
 };

--- a/src/poker/gameorchestrator.cpp
+++ b/src/poker/gameorchestrator.cpp
@@ -25,13 +25,13 @@ GameOrchestrator::GameOrchestrator(PokerGame *gameAnalyzer,
                                    Account   &playerAcct,
                                    quint8     renderDelay,
                                    QObject   *parent)
-    : _gameAnalyzer (gameAnalyzer),
+    : QObject       (parent),
+      _gameAnalyzer (gameAnalyzer),
       _nbHandsPerBet(nbHandsToPlay),
       _playerAccount(playerAcct),
       _renderDelayMS(renderDelay),
       _fakeGame     (false),
-      _handInProg   (false),
-      QObject       (parent)
+      _handInProg   (false)
 {
     // TODO: How many hand should we max out at? This is a fun thought experiment ... probably depends on screen reso.?
     _gameCards.reserve(nbHandsToPlay);
@@ -47,13 +47,13 @@ GameOrchestrator::GameOrchestrator(PokerGame *gameAnalyzer,
                                    Hand      &fixedHandTest,
                                    Account   &playerAcct,
                                    QObject   *parent)
-    : _gameAnalyzer (gameAnalyzer),
+    : QObject       (parent),
+      _gameAnalyzer (gameAnalyzer),
       _nbHandsPerBet(1),
       _playerAccount(playerAcct),
       _renderDelayMS(0),
       _fakeGame     (true),
-      _handInProg   (false),
-      QObject       (parent)
+      _handInProg   (false)
 {
     _gameCards.reserve(1);
     Deck cardDeckToIgnore(Deck::FULL_FRENCH);
@@ -122,7 +122,6 @@ void GameOrchestrator::dealDraw()
 
         // Take the bet amount from the account * the number of hands played
         _playerAccount.withdraw(_nbHandsPerBet * _gameAnalyzer->getCreditsPerBet());
-        emit updatedBalance(_playerAccount.balance());
 
         // Do not actually draw any cards if in a unit test simulation mode
         if (!_fakeGame) {
@@ -206,7 +205,6 @@ void GameOrchestrator::dealDraw()
         }
         _handInProg = false;
         emit gameInProgress(_handInProg);
-        emit updatedBalance(_playerAccount.balance());
     }
 }
 

--- a/src/poker/gameorchestrator.h
+++ b/src/poker/gameorchestrator.h
@@ -169,11 +169,6 @@ signals:
     void gameWinnings(qint32 winningsSoFar);
 
     /**
-     * @brief updatedBalance indicates the current balance in the account
-     */
-    void updatedBalance(qint32 newCreditBalance);
-
-    /**
      * @brief primaryCardRevealed indicates a card on the primary hand was revealed (at index and what the card was)
      */
     void primaryCardRevealed(int cardIdx, PlayingCard card);

--- a/src/ui/gameaccountwindow.h
+++ b/src/ui/gameaccountwindow.h
@@ -40,16 +40,23 @@ public:
 
 public slots:
     /**
-     * @brief setAccountBalance is used to store the balance of the account from the balance spinbox
+     * @brief updateAccountBalance will reflect the balance of credits in a player's account in a LCD display widget
      */
-    void setAccountBalance();
-
-    //TODO: another slot to track changes in balance?
+    void updateAccountBalance(quint32 updatedBalance);
 
     /**
-     * @brief startGame begins a game of Jacks Or Better to test window spawning and game logic
+     * @brief startGame begins a game of whatever PokerGame is pointed to
      */
-    void startGame(PokerGame *gameLogicPointer, int numberOfHands);
+    void startGame(PokerGame *gameLogicPointer);
+
+    /**
+     * @brief      changeNumberOfHands sets the number of hands a player will play at a time in the game orchestrator
+     *
+     * @param[in]  increaseDecrease use -1 to decrease the hands played, 1 to increase it
+     *
+     * @note       The minimum value held is 1, the maximum value is ---TODO--- (after UI supports multi-hands)
+     */
+    void changeNumberOfHands(int increaseDecrease);
 
 private:
     // Game-Specific Items

--- a/src/ui/gameaccountwindow.ui
+++ b/src/ui/gameaccountwindow.ui
@@ -6,42 +6,107 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>883</width>
-    <height>391</height>
+    <width>813</width>
+    <height>383</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>VidPokerTerminal</string>
   </property>
+  <property name="styleSheet">
+   <string notr="true">font-size: 15pt;
+background-color: rgb(6, 139, 3);
+color: rgb(255, 255, 255);</string>
+  </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0,0,0">
+   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0,0">
     <item>
      <widget class="QLabel" name="label">
       <property name="text">
-       <string>Welcome to VidPokerTerm, the Qt-Based Video Poker Terminal!</string>
+       <string>Welcome to VidPokerTerm! Add credits and select a game.</string>
       </property>
      </widget>
     </item>
     <item>
      <widget class="QFrame" name="accountFrame">
+      <property name="styleSheet">
+       <string notr="true">QPushButton {
+    color: lawngreen;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: blue;
+}
+QPushButton:focus {
+    color: lawngreen;
+    background-color: blue;
+    border-style: outset;
+    border-width: 2px;
+    border-color: blue;
+}
+QPushButton:pressed {
+    color: blue;
+    background-color: lawngreen;
+    border-style: outset;
+    border-width: 2px;
+    border-color: lawngreen;
+}
+</string>
+      </property>
       <property name="frameShape">
        <enum>QFrame::StyledPanel</enum>
       </property>
       <property name="frameShadow">
        <enum>QFrame::Raised</enum>
       </property>
-      <layout class="QHBoxLayout" name="horizontalLayout">
+      <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1,0,1,1,1">
        <item>
         <widget class="QLabel" name="label_2">
          <property name="text">
-          <string>Credits Available</string>
+          <string>Credits</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QSpinBox" name="accountBalance">
-         <property name="maximum">
-          <number>1000000000</number>
+        <widget class="QLCDNumber" name="creditCountLCD">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="digitCount">
+          <number>6</number>
+         </property>
+         <property name="segmentStyle">
+          <enum>QLCDNumber::Flat</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="addAcct100">
+         <property name="text">
+          <string>+100</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="addAcct10">
+         <property name="text">
+          <string>+10</string>
          </property>
         </widget>
        </item>
@@ -52,61 +117,152 @@
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QPushButton" name="addAcct10">
-         <property name="text">
-          <string>Add 10</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="addAcct100">
-         <property name="text">
-          <string>Add 100</string>
-         </property>
-        </widget>
-       </item>
       </layout>
      </widget>
     </item>
     <item>
      <widget class="QFrame" name="gameSelectFrame">
+      <property name="styleSheet">
+       <string notr="true">QPushButton {
+    color: lawngreen;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: blue;
+}
+QPushButton:focus {
+    color: lawngreen;
+    background-color: blue;
+    border-style: outset;
+    border-width: 2px;
+    border-color: blue;
+}
+QPushButton:pressed {
+    color: blue;
+    background-color: lawngreen;
+    border-style: outset;
+    border-width: 2px;
+    border-color: lawngreen;
+}
+</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2"/>
+     </widget>
+    </item>
+    <item>
+     <widget class="QFrame" name="frame">
+      <property name="styleSheet">
+       <string notr="true">QPushButton {
+    color: lawngreen;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: blue;
+}
+QPushButton:focus {
+    color: lawngreen;
+    background-color: blue;
+    border-style: outset;
+    border-width: 2px;
+    border-color: blue;
+}
+QPushButton:pressed {
+    color: blue;
+    background-color: lawngreen;
+    border-style: outset;
+    border-width: 2px;
+    border-color: lawngreen;
+}
+</string>
+      </property>
       <property name="frameShape">
        <enum>QFrame::StyledPanel</enum>
       </property>
       <property name="frameShadow">
        <enum>QFrame::Raised</enum>
       </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="1">
-        <widget class="QLabel" name="handsToPlayText">
+      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="4,4,0,0,1">
+       <item>
+        <widget class="QPushButton" name="exitButton">
+         <property name="styleSheet">
+          <string notr="true">QPushButton {
+    color: lawngreen;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: blue;
+}
+QPushButton:focus {
+    color: blue;
+    background-color: salmon;
+    border-style: outset;
+    border-width: 2px;
+    border-color: blue;
+}
+QPushButton:pressed {
+    color: salmon;
+    background-color: blue;
+    border-style: outset;
+    border-width: 2px;
+    border-color: salmon;
+}
+</string>
+         </property>
          <property name="text">
-          <string># hands / round</string>
+          <string>Exit</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="gameText">
+       <item>
+        <widget class="QPushButton" name="aboutButton">
          <property name="text">
-          <string>Game</string>
+          <string>About...</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="handsToPlayLabel">
+         <property name="text">
+          <string>Hands</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLCDNumber" name="handsToPlayLCD">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="digitCount">
+          <number>3</number>
+         </property>
+         <property name="segmentStyle">
+          <enum>QLCDNumber::Flat</enum>
          </property>
         </widget>
        </item>
       </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="exitButton">
-      <property name="text">
-       <string>Exit</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="aboutButton">
-      <property name="text">
-       <string>About...</string>
-      </property>
      </widget>
     </item>
     <item>
@@ -122,7 +278,58 @@
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
+        <widget class="QPushButton" name="moveDnSoftkey">
+         <property name="focusPolicy">
+          <enum>Qt::ClickFocus</enum>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QPushButton:disabled {
+    color: black;
+    background-color: gray;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gray;
+    font-size: 15pt;
+}
+QPushButton {
+    color: black;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:focused {
+    color: red;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
+QPushButton:pressed {
+    color: yellow;
+    background-color: black;
+    border-style: outset;
+    border-width: 2px;
+    border-color: yellow;
+    font-size: 15pt;
+}
+</string>
+         </property>
+         <property name="text">
+          <string>Next</string>
+         </property>
+         <property name="shortcut">
+          <string>N</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="moveUpSoftkey">
+         <property name="focusPolicy">
+          <enum>Qt::ClickFocus</enum>
+         </property>
          <property name="styleSheet">
           <string notr="true">QPushButton:disabled {
     color: black;
@@ -140,6 +347,14 @@ QPushButton {
     border-color: gold;
     font-size: 15pt;
 }
+QPushButton:focused {
+    color: red;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
 QPushButton:pressed {
     color: yellow;
     background-color: black;
@@ -151,12 +366,18 @@ QPushButton:pressed {
 </string>
          </property>
          <property name="text">
-          <string>softkey1</string>
+          <string>Back</string>
+         </property>
+         <property name="shortcut">
+          <string>M</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="moveDownSoftkey">
+        <widget class="QPushButton" name="nbHandsDec">
+         <property name="focusPolicy">
+          <enum>Qt::ClickFocus</enum>
+         </property>
          <property name="styleSheet">
           <string notr="true">QPushButton:disabled {
     color: black;
@@ -174,6 +395,14 @@ QPushButton {
     border-color: gold;
     font-size: 15pt;
 }
+QPushButton:focused {
+    color: red;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
 QPushButton:pressed {
     color: yellow;
     background-color: black;
@@ -185,12 +414,18 @@ QPushButton:pressed {
 </string>
          </property>
          <property name="text">
-          <string>softkey2</string>
+          <string>Hands (-)</string>
+         </property>
+         <property name="shortcut">
+          <string>,</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="pushButton_3">
+        <widget class="QPushButton" name="nbHandsInc">
+         <property name="focusPolicy">
+          <enum>Qt::ClickFocus</enum>
+         </property>
          <property name="styleSheet">
           <string notr="true">QPushButton:disabled {
     color: black;
@@ -208,34 +443,8 @@ QPushButton {
     border-color: gold;
     font-size: 15pt;
 }
-QPushButton:pressed {
-    color: yellow;
-    background-color: black;
-    border-style: outset;
-    border-width: 2px;
-    border-color: yellow;
-    font-size: 15pt;
-}
-</string>
-         </property>
-         <property name="text">
-          <string>softkey3</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_4">
-         <property name="styleSheet">
-          <string notr="true">QPushButton:disabled {
-    color: black;
-    background-color: gray;
-    border-style: outset;
-    border-width: 2px;
-    border-color: gray;
-    font-size: 15pt;
-}
-QPushButton {
-    color: black;
+QPushButton:focused {
+    color: red;
     background-color: yellow;
     border-style: outset;
     border-width: 2px;
@@ -253,12 +462,18 @@ QPushButton:pressed {
 </string>
          </property>
          <property name="text">
-          <string>softkey4</string>
+          <string>Hands (+)</string>
+         </property>
+         <property name="shortcut">
+          <string>.</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QPushButton" name="selectSoftkey">
+         <property name="focusPolicy">
+          <enum>Qt::ClickFocus</enum>
+         </property>
          <property name="styleSheet">
           <string notr="true">QPushButton:disabled {
     color: black;
@@ -276,6 +491,14 @@ QPushButton {
     border-color: gold;
     font-size: 15pt;
 }
+QPushButton:focused {
+    color: red;
+    background-color: yellow;
+    border-style: outset;
+    border-width: 2px;
+    border-color: gold;
+    font-size: 15pt;
+}
 QPushButton:pressed {
     color: yellow;
     background-color: black;
@@ -287,7 +510,10 @@ QPushButton:pressed {
 </string>
          </property>
          <property name="text">
-          <string>softkey5</string>
+          <string>Select</string>
+         </property>
+         <property name="shortcut">
+          <string>/</string>
          </property>
         </widget>
        </item>
@@ -297,6 +523,13 @@ QPushButton:pressed {
    </layout>
   </widget>
  </widget>
+ <tabstops>
+  <tabstop>addAcct100</tabstop>
+  <tabstop>addAcct10</tabstop>
+  <tabstop>resetAcct0</tabstop>
+  <tabstop>exitButton</tabstop>
+  <tabstop>aboutButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/gameorchestratorwindow.cpp
+++ b/src/ui/gameorchestratorwindow.cpp
@@ -82,7 +82,7 @@ GameOrchestratorWindow::GameOrchestratorWindow(Account   &playerAccount,
     connect(_gameOrc, &GameOrchestrator::gameWinnings, this, &GameOrchestratorWindow::currentWinnings);
 
     // Connect the account balance to the display
-    connect(_gameOrc, &GameOrchestrator::updatedBalance, this, &GameOrchestratorWindow::currentBalance);
+    connect(&_playerCredits, &Account::balanceChanged, this, &GameOrchestratorWindow::currentBalance);
 
     // Card holding (for the primary hand) - set to disabled to start
     PrimaryHand->enableHolds(false);
@@ -120,8 +120,12 @@ GameOrchestratorWindow::GameOrchestratorWindow(Account   &playerAccount,
 
 GameOrchestratorWindow::~GameOrchestratorWindow()
 {
+    // Cleanup heap-allocated objects
     delete _gameOrc;
     delete ui;
+
+    // TODO: need to implement a stateless _gameLogic! Ensure that the game logic does not have any game state leftover
+    _gameLogic->reset();
 }
 
 void GameOrchestratorWindow::resizeEvent(QResizeEvent *event)
@@ -177,6 +181,7 @@ void GameOrchestratorWindow::dealToDraw(bool showDraw)
         ui->drawDealButton->setText("Deal");
         ui->drawDealButton->setShortcut(QKeySequence("/"));
         ui->returnButton->setDisabled(false);
+        ui->returnButton->setShortcut(QKeySequence("N"));
         ui->betIncrementButton->setDisabled(false);
         ui->maxBetButton->setDisabled(false);
     }

--- a/src/ui/gameorchestratorwindow.ui
+++ b/src/ui/gameorchestratorwindow.ui
@@ -296,7 +296,7 @@ QPushButton:pressed {
           <string>Return</string>
          </property>
          <property name="shortcut">
-          <string>Esc</string>
+          <string>N</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Created signals/slots to show all player credit updates (rather than through the orchestrator). This allowed the credit amounts to be updated live in the main account/launcher window.

Created softkeys for the main launcher window so credits can be changed and the interface navigated with only 5 buttons (the softkeys themselves):
- Move Down
- Move Up
- Increment # of hands to play
- Decrement # of hands to play
- Select the "focused" widget

The game orchestrator is entirely game-agnostic now, it is started with a pointer to a subclassed PokerGame .. therefore the game selector (main) window must allocate all supported games and pass the pointer to the new orchestrator constructor.