### PR TITLE
Game Orchestrator - Multiple-Hand-Game Support

### DIFF
--- a/src/poker/bonuspoker.cpp
+++ b/src/poker/bonuspoker.cpp
@@ -35,8 +35,11 @@ BonusPoker::BonusPoker() : PokerGame("Bonus Poker")
     };
 }
 
-void BonusPoker::analyzeHand(const Hand &gameHand)
+void BonusPoker::determineHandAndWin(const Hand &gameHand,
+                                     quint32     nbCreditsBet,
+                                     QString    &winningHand,
+                                     quint32    &creditsWon)
 {
-    ;
+    winningHand = "";
+    creditsWon  = 0;
 }
-

--- a/src/poker/bonuspoker.h
+++ b/src/poker/bonuspoker.h
@@ -46,9 +46,12 @@ public:
     /**
      * @brief      Analyzes a hand against the Bonus Poker payout table / game rules
      *
-     * @param[in]  gameHand       Single hand of a poker game
+     * @param[in]  gameHand       A set of PlayingCards comprising the player's hand construction
+     * @param[in]  nbCreditsBet   Number of credits the player has staked for gameHand
+     * @param[out] winningHand    QString buffer to write the winning hand (if any)
+     * @param[out] creditsWon     Number of credits the player is entitled to win based on the gameHand and bet
      */
-    void analyzeHand(const Hand &gameHand);
+    void determineHandAndWin(const Hand &gameHand, quint32 nbCreditsBet, QString &winningHand, quint32 &creditsWon);
 };
 
 #endif // BONUSPOKER_H

--- a/src/poker/deck.cpp
+++ b/src/poker/deck.cpp
@@ -72,6 +72,11 @@ void Deck::removeCard(const PlayingCard &cardToRemove)
     }
 }
 
+void Deck::addCard(const PlayingCard cardToInsert)
+{
+    _cardDeck.push_back(cardToInsert);
+}
+
 void Deck::reset()
 {
     if (_typeOfDeck == FULL_FRENCH) {

--- a/src/poker/deck.h
+++ b/src/poker/deck.h
@@ -81,6 +81,15 @@ public:
     void removeCard(const PlayingCard &cardToRemove);
 
     /**
+     * @brief      Puts the cardToReplace into the deck. This is also principally intended for multi-hand games.
+     *             Placing a card back into the deck will hurt it's shuffled-ness, so be sure to shuffle after doing
+     *             this operation.
+     *
+     * @param[in]  cardToInsert    Card to put into the deck
+     */
+    void addCard(const PlayingCard cardToInsert);
+
+    /**
      * @brief      Resets the internal black list, restoring the deck back to full eligibility
      */
     void reset();

--- a/src/poker/gameorchestrator.cpp
+++ b/src/poker/gameorchestrator.cpp
@@ -101,10 +101,14 @@ void GameOrchestrator::dealDraw()
     if (!_handInProg) {
         /*
          * First stage of the game, no cards dealt so ensure deck is full + shuffled and the target hand(s) empty
+         * The player only interacts with the first hand, so the others will only be initialized and shuffled
          */
         if (!_fakeGame) {
-            _gameCards[0].first.reset();
-            _gameCards[0].second.reset();
+            for (QPair<Deck, Hand> &handDeck : _gameCards) {
+                handDeck.first.reset();
+                handDeck.second.reset();
+            }
+            // Only shuffle the deck the player is interacting with. The secondary decks will be shuffled at draw time.
             _gameCards[0].first.shuffle();
         }
 
@@ -121,6 +125,7 @@ void GameOrchestrator::dealDraw()
         // Set the in progress state right away so the UI will be updated before dealing out cards
         _handInProg = true;
         emit gameInProgress(_handInProg);
+        emit operating(true);
 
         // Take the bet amount from the account * the number of hands played
         _playerAccount.withdraw(_nbHandsToPlay * _betsPerHand);
@@ -138,6 +143,13 @@ void GameOrchestrator::dealDraw()
                     _gameCards[0].second.addCard(nextCard);
                     emit primaryCardRevealed(cardIdx, nextCard);
                 }
+
+                // For all secondary hands, fill them with null / placeholder cards
+                for (int handIdx = 1; handIdx < _gameCards.size(); ++handIdx) {
+                    for (quint32 cardIdx = 0; cardIdx < Hand::kCardsPerHand; ++cardIdx) {
+                        _gameCards[handIdx].second.addCard(PlayingCard());
+                    }
+                }
             } catch (std::runtime_error &exception) {
                 qDebug() << "WARNING: " << exception.what();
                 return;
@@ -149,6 +161,7 @@ void GameOrchestrator::dealDraw()
             quint32 handWinCredits;
             _gameAnalyzer->determineHandAndWin(_gameCards[0].second, _betsPerHand, handAnalyResult, handWinCredits);
             emit primaryHandUpdated(handAnalyResult, 0);
+            emit operating(false);
         }
     } else {
         /*
@@ -176,20 +189,33 @@ void GameOrchestrator::dealDraw()
             flipCard5 = true;
         }
         emit cardsToRedraw(flipCard1, flipCard2, flipCard3, flipCard4, flipCard5);
+        emit operating(true);
 
         // ... then reveal them
         quint32 totalWinnings = 0;
         for (quint32 handIdx = 0; handIdx < _nbHandsToPlay; ++handIdx) {
+            // Shuffle all secondary decks before drawing!
+            if (handIdx != 0) {
+                _gameCards[handIdx].first.shuffle();
+            }
+
             try {
                 for (quint32 cardIdx = 0; cardIdx < Hand::kCardsPerHand; ++cardIdx) {
-                    if (!_gameCards[0].second.cardHeld(cardIdx)) {
+                    if (!_gameCards[handIdx].second.cardHeld(cardIdx)) {
                         // Actual terminals like to give the appearance of a game, so introduce a delay between showing
                         if (_renderDelayMS != 0)
                             QThread::msleep(_renderDelayMS);
 
-                        PlayingCard nextCard = _gameCards[0].first.drawCard();
-                        _gameCards[0].second.replaceCard(cardIdx, nextCard);
-                        emit primaryCardRevealed(cardIdx, nextCard);
+                        PlayingCard nextCard = _gameCards[handIdx].first.drawCard();
+                        _gameCards[handIdx].second.replaceCard(cardIdx, nextCard);
+
+                        if (handIdx == 0) {
+                            // Primary hand cards
+                            emit primaryCardRevealed(cardIdx, nextCard);
+                        } else {
+                            // Secondary hand(s) cards
+                            emit secondaryCardRevealed(handIdx - 1, cardIdx, nextCard, true);
+                        }
                     }
                 }
             } catch (std::runtime_error &exception) {
@@ -204,13 +230,19 @@ void GameOrchestrator::dealDraw()
             _playerAccount.add(handWinCreds);
 
             // Update the front-end with the individual hand winnings and total winnings (for multi-handed games)
-            // TODO: so far just the primary hand...
-            emit primaryHandUpdated(handAnalyRslt, handWinCreds);
+            if (handIdx == 0) {
+                // Primary Hand Analysis
+                emit primaryHandUpdated(handAnalyRslt, handWinCreds);
+            } else {
+                // Secondary Hand Analysis
+                emit secondaryHandUpdated(handIdx - 1, handAnalyRslt, handWinCreds);
+            }
             totalWinnings += handWinCreds;
             emit gameWinnings(totalWinnings);
         }
         _handInProg = false;
         emit gameInProgress(_handInProg);
+        emit operating(false);
     }
 }
 
@@ -223,12 +255,33 @@ void GameOrchestrator::hold(quint8 cardPosition, bool canHold)
 
     // Otherwise set the hold
     try {
+        // First the primary hand
         _gameCards[0].second.holdCard(cardPosition, canHold);
+
+        // See which card was actually held so it can be removed from any secondary decks
+        const PlayingCard heldCard = _gameCards[0].second.cardAt(cardPosition);
+
+        // Then the secondary hands (+ emit to the orchestrator UI that there is a card to show or hide)
+        for (int secondaryIdx = 1; secondaryIdx < _gameCards.size(); ++secondaryIdx) {
+            if (canHold) {
+                // Holding a card will take it out of the deck
+                _gameCards[secondaryIdx].first.removeCard(heldCard);
+                _gameCards[secondaryIdx].second.replaceCard(cardPosition, heldCard);
+                _gameCards[secondaryIdx].second.holdCard(cardPosition, true);
+                emit secondaryCardRevealed(secondaryIdx - 1, cardPosition, heldCard, true);
+            } else {
+                // Un-Holding a card will put it back
+                // WARNING: as a result of this, the deck will lose its randomness, so secondary decks must be shuffled
+                //          before drawing from for the final hand(s) conditions.
+                _gameCards[secondaryIdx].second.replaceCard(cardPosition, PlayingCard());
+                _gameCards[secondaryIdx].first.addCard(heldCard);
+                _gameCards[secondaryIdx].second.holdCard(cardPosition, false);
+                emit secondaryCardRevealed(secondaryIdx - 1, cardPosition, heldCard, false);
+            }
+        }
     } catch (std::runtime_error &exception) {
         qDebug() << "WARNING: " << exception.what();
     }
-
-    // TODO: must repeat for each hand being played and emit each card across all hands
 }
 
 void GameOrchestrator::cycleBetAmount()

--- a/src/poker/gameorchestrator.h
+++ b/src/poker/gameorchestrator.h
@@ -81,7 +81,7 @@ public:
      *
      * @param[in]  credits
      */
-    void setCreditsToBet(qint8 credits);
+    void setCreditsToBet(qint32 credits);
 
     /**
      * @brief creditsToBet fetches how many credits the player must apply to a deal as stored in the gameAnalyzer.
@@ -180,7 +180,8 @@ signals:
 
 private:
     PokerGame                  *_gameAnalyzer;
-    quint32                     _nbHandsPerBet;
+    quint32                     _nbHandsToPlay;
+    quint32                     _betsPerHand;
     Account                    &_playerAccount;
     quint8                      _renderDelayMS;
     bool                        _fakeGame;

--- a/src/poker/gameorchestrator.h
+++ b/src/poker/gameorchestrator.h
@@ -159,6 +159,12 @@ signals:
     void gameInProgress(bool sayDrawNotDeal);
 
     /**
+     * @brief operating indicates the orchestrator has tasks in progress (so asking for another deal-draw would cause
+     *        an inconsistent state).
+     */
+    void operating(bool handsDealing);
+
+    /**
      * @brief primaryHandUpdated indicates the result of the hand analysis and any winnings associated with that hand
      */
     void primaryHandUpdated(const QString &handString, quint32 winning);
@@ -172,6 +178,16 @@ signals:
      * @brief primaryCardRevealed indicates a card on the primary hand was revealed (at index and what the card was)
      */
     void primaryCardRevealed(int cardIdx, PlayingCard card);
+
+    /**
+     * @brief secondaryCardRevealed indicates card at cardIdx on a secondary hand handIdx is displayable (show == true)
+     */
+    void secondaryCardRevealed(int handIdx, int cardIdx, PlayingCard card, bool show);
+
+    /**
+     * @brief secondaryHandUpdated
+     */
+    void secondaryHandUpdated(int handIdx, const QString &handString, quint32 winning);
 
     /**
      * @brief renderSpeed indicates the card draw speed was changed

--- a/src/poker/hand.cpp
+++ b/src/poker/hand.cpp
@@ -25,12 +25,14 @@ const quint8 Hand::kCardsPerHand = 5;
 
 Hand::Hand()
 {
-    // Claim 5 spaces for cards
+    // Claim 5 spaces for cards, to be used later
     _handCardStatus.reserve(kCardsPerHand);
 }
 
 Hand::Hand(PlayingCard card1, PlayingCard card2, PlayingCard card3, PlayingCard card4, PlayingCard card5)
 {
+    // Claim 5 spaces for cards
+    _handCardStatus.reserve(kCardsPerHand);
     addCard(card1);
     addCard(card2);
     addCard(card3);
@@ -44,6 +46,11 @@ void Hand::addCard(PlayingCard card)
         throw std::runtime_error("Adding card will exceed hand limit");
     }
     _handCardStatus.push_back({card, false});
+}
+
+const PlayingCard Hand::cardAt(quint8 cardIdx) const
+{
+    return _handCardStatus[cardIdx].first;
 }
 
 void Hand::holdCard(quint8 cardNum, bool hold)

--- a/src/poker/hand.h
+++ b/src/poker/hand.h
@@ -61,6 +61,15 @@ public:
     void addCard(PlayingCard card);
 
     /**
+     * @brief      Allows a client to copy the card at a specified hand position for comparisons
+     *
+     * @param[in]  cardIdx    Position from the hand to peek at the card
+     *
+     * @return     a const copy of the playing card
+     */
+    const PlayingCard cardAt(quint8 cardIdx) const;
+
+    /**
      * @brief      Sets the hold status of a card in the hand
      *
      * @param[in]  cardNum    Index of the card to hold

--- a/src/poker/jacksorbetter.cpp
+++ b/src/poker/jacksorbetter.cpp
@@ -35,7 +35,10 @@ JacksOrBetter::JacksOrBetter() : PokerGame("Jacks or Better")
     };
 }
 
-void JacksOrBetter::analyzeHand(const Hand &gameHand)
+void JacksOrBetter::determineHandAndWin(const Hand &gameHand,
+                                        quint32     nbCreditsBet,
+                                        QString    &winningHand,
+                                        quint32    &creditsWon)
 {
     // Convert the hand to a vector so that algorithms can re-sort the cards as needed to efficiently determine wins
     QVector<PlayingCard> singleHand = gameHand.handToVector();
@@ -43,39 +46,36 @@ void JacksOrBetter::analyzeHand(const Hand &gameHand)
     // Sort the hand by order of highest to lowest card rank, as required by some hand analysis algorithms
     HandAnalysis::sortHandVector(singleHand);
 
-    // Find the credits actually bet so the correct payout column will be chosen
-    quint8 payoutArrayIdx = getCreditsPerBet() - 1;
-
     // Go in order of best hand to nothing, so we ensure the best winnings possible are met
     if (HandAnalysis::RoyalFlush(singleHand)) {
-        setHandResult(_handPayouts[0].handString);
-        setWinnings(_handPayouts[0].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[0].handString;
+        creditsWon  = _handPayouts[0].payoutCredits[nbCreditsBet - 1];
     } else if (HandAnalysis::StraightFlush(singleHand)) {
-        setHandResult(_handPayouts[1].handString);
-        setWinnings(_handPayouts[1].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[1].handString;
+        creditsWon  = _handPayouts[1].payoutCredits[nbCreditsBet - 1];
     } else if (HandAnalysis::FourOfAKind(singleHand)) {
-        setHandResult(_handPayouts[2].handString);
-        setWinnings(_handPayouts[2].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[2].handString;
+        creditsWon  = _handPayouts[2].payoutCredits[nbCreditsBet - 1];
     } else if (HandAnalysis::FullHouse(singleHand)) {
-        setHandResult(_handPayouts[3].handString);
-        setWinnings(_handPayouts[3].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[3].handString;
+        creditsWon  = _handPayouts[3].payoutCredits[nbCreditsBet - 1];
     } else if (HandAnalysis::Flush(singleHand)) {
-        setHandResult(_handPayouts[4].handString);
-        setWinnings(_handPayouts[4].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[4].handString;
+        creditsWon  = _handPayouts[4].payoutCredits[nbCreditsBet - 1];
     } else if (HandAnalysis::Straight(singleHand)) {
-        setHandResult(_handPayouts[5].handString);
-        setWinnings(_handPayouts[5].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[5].handString;
+        creditsWon  = _handPayouts[5].payoutCredits[nbCreditsBet - 1];
     } else if (HandAnalysis::ThreeOfAKind(singleHand)) {
-        setHandResult(_handPayouts[6].handString);
-        setWinnings(_handPayouts[6].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[6].handString;
+        creditsWon  = _handPayouts[6].payoutCredits[nbCreditsBet - 1];
     } else if (HandAnalysis::TwoPair(singleHand)) {
-        setHandResult(_handPayouts[7].handString);
-        setWinnings(_handPayouts[7].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[7].handString;
+        creditsWon  = _handPayouts[7].payoutCredits[nbCreditsBet - 1];
     } else if (HandAnalysis::JacksOrBetter(singleHand)) {
-        setHandResult(_handPayouts[8].handString);
-        setWinnings(_handPayouts[8].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[8].handString;
+        creditsWon  = _handPayouts[8].payoutCredits[nbCreditsBet - 1];
     } else {
-        setHandResult(_handPayouts[9].handString);
-        setWinnings(_handPayouts[9].payoutCredits[payoutArrayIdx]);
+        winningHand = _handPayouts[9].handString;
+        creditsWon  = _handPayouts[9].payoutCredits[nbCreditsBet - 1];
     }
 }

--- a/src/poker/jacksorbetter.h
+++ b/src/poker/jacksorbetter.h
@@ -27,26 +27,29 @@ public:
      * @brief The classic popular video poker game, "Jacks or Better". This is the desirable 9-6 Jacks or Better game.
      *
      *        Payout Table (as initialized by the Constructor):
-     *        +-----------------+-----+-----+-----+-----+-----+
-     *        | Royal Flush     |  250|  500|  750| 1000| 4000|
-     *        | Straight Flush  |   50|  100|  150|  200|  250|
-     *        | 4 of a Kind     |   25|   50|   75|  100|  125|
-     *        | Full House      |    9|   18|   27|   36|   45|
-     *        | Flush           |    6|   12|   18|   24|   30|
-     *        | Straight        |    4|    8|   12|   16|   20|
-     *        | 3 of a Kind     |    3|    6|    9|   12|   15|
-     *        | 2 Pair          |    2|    4|    6|    8|   10|
-     *        | Jacks or Better |    1|    2|    3|    4|    5|
-     *        +-----------------+-----+-----+-----+-----+-----+
+     *        +-----------------+------+------+------+------+------+
+     *        | Royal Flush     |  250 |  500 |  750 | 1000 | 4000 |
+     *        | Straight Flush  |   50 |  100 |  150 |  200 |  250 |
+     *        | 4 of a Kind     |   25 |   50 |   75 |  100 |  125 |
+     *        | Full House      |    9 |   18 |   27 |   36 |   45 |
+     *        | Flush           |    6 |   12 |   18 |   24 |   30 |
+     *        | Straight        |    4 |    8 |   12 |   16 |   20 |
+     *        | 3 of a Kind     |    3 |    6 |    9 |   12 |   15 |
+     *        | 2 Pair          |    2 |    4 |    6 |    8 |   10 |
+     *        | Jacks or Better |    1 |    2 |    3 |    4 |    5 |
+     *        +-----------------+------+------+------+------+------+
      */
     explicit JacksOrBetter();
 
     /**
-     * @brief      Analyzes a hand against the Jacks-or-Better game rules
+     * @brief determineHandAndWin Analyzes a hand against the Jacks-or-Better game rules and the requested bet amount
      *
-     * @param[in]  gameHand       Single hand of a poker game
+     * @param[in]  gameHand       A set of PlayingCards comprising the player's hand construction
+     * @param[in]  nbCreditsBet   Number of credits the player has staked for gameHand
+     * @param[out] winningHand    QString buffer to write the winning hand (if any)
+     * @param[out] creditsWon     Number of credits the player is entitled to win based on the gameHand and bet
      */
-    void analyzeHand(const Hand &gameHand);
+    void determineHandAndWin(const Hand &gameHand, quint32 nbCreditsBet, QString &winningHand, quint32 &creditsWon);
 };
 
 #endif // JACKSORBETTER_H

--- a/src/poker/playingcard.cpp
+++ b/src/poker/playingcard.cpp
@@ -17,13 +17,19 @@
 
 #include "playingcard.h"
 
-PlayingCard::PlayingCard() {}
+PlayingCard::PlayingCard() : _null(true) {}
 
-PlayingCard::PlayingCard(CardSuit cardSuit, CardValue cardValue) : _suit(cardSuit), _value(cardValue) {}
+PlayingCard::PlayingCard(CardSuit cardSuit, CardValue cardValue) : _null(false), _suit(cardSuit), _value(cardValue) {}
+
+bool PlayingCard::fakeCard() const {return _null;}
 
 bool PlayingCard::operator==(const PlayingCard &card) const
 {
-    return (this->suit() == card.suit()) && (this->value() == card.value());
+    return ((this->fakeCard() && card.fakeCard()) ||
+            (!this->fakeCard() &&
+             !card.fakeCard()  &&
+             (this->suit() == card.suit()) &&
+             (this->value() == card.value())));
 }
 
 PlayingCard::CardSuit PlayingCard::suit() const   {return _suit;}

--- a/src/poker/playingcard.h
+++ b/src/poker/playingcard.h
@@ -58,6 +58,13 @@ public:
     explicit PlayingCard(CardSuit cardSuit, CardValue cardValue);
 
     /**
+     * @brief      Determines if this instance is an actual card and not a 'placeholder'
+     *
+     * @return     true if the card's null flag is set
+     */
+    bool fakeCard() const;
+
+    /**
      * @brief operator == overloading for use by the Deck's removeCard() feature
      */
     bool operator==(const PlayingCard &card) const;
@@ -77,6 +84,7 @@ public:
     CardValue value() const;
 
 private:
+    bool      _null;    // A null card can be used to have a placeholder in a hand (say for holding at a position)
     CardSuit  _suit;
     CardValue _value;
 };

--- a/src/poker/pokergame.cpp
+++ b/src/poker/pokergame.cpp
@@ -19,47 +19,28 @@
 
 #include "commonhandanalysis.h"
 
-PokerGame::PokerGame(const QString &gameName)
-    : _gameName(gameName)
-{
-    setCreditsPerBet(1);
-    reset();
-}
+PokerGame::PokerGame(const QString &gameName) : _gameName(gameName) {}
 
 PokerGame::~PokerGame() {}
 
-const QString PokerGame::gameName() const           {return _gameName;}
+const QString PokerGame::gameName() const {return _gameName;}
 
-void PokerGame::setCreditsPerBet(quint8 credits)
+bool PokerGame::creditBetValid(quint32 nbCredPerBet) const
 {
-    if (credits == 0 || credits > 5) {
+    if (nbCredPerBet == 0 || nbCredPerBet > 5) {
+        return false;
+    }
+    return true;
+}
+
+void PokerGame::currentPayTable(quint32 nbCreditsPerBet, QVector<QPair<const QString, int>> &payoutForBet) const
+{
+    if (!creditBetValid(nbCreditsPerBet)) {
         throw std::runtime_error("Invalid number of credits for game");
     }
 
-    _credPerBet = credits;
-}
-
-quint8 PokerGame::getCreditsPerBet() const          {return _credPerBet;}
-
-void PokerGame::setHandResult(QString handResult)   {_handResult = handResult;}
-
-QString PokerGame::handResult() const               {return _handResult;}
-
-void PokerGame::setWinnings(quint32 winningCredits) {_winnings = winningCredits;}
-
-quint32 PokerGame::getWinnings() const              {return _winnings;}
-
-void PokerGame::reset()
-{
-    _handResult = "";
-    _winnings   = 0;
-    setCreditsPerBet(1);
-}
-
-void PokerGame::currentPayTable(QVector<QPair<const QString, int>> &payoutForBet) const
-{
     for (const Parameters &singleHand : _handPayouts) {
-        QPair<QString, int> handPayout(singleHand.handString, singleHand.payoutCredits[_credPerBet - 1]);
+        QPair<QString, int> handPayout(singleHand.handString, singleHand.payoutCredits[nbCreditsPerBet - 1]);
         payoutForBet.push_back(handPayout);
     }
 }

--- a/src/poker/pokergame.h
+++ b/src/poker/pokergame.h
@@ -36,12 +36,12 @@ public:
     };
 
     /**
-     * @brief      ~
+     * @brief Abstract game paytable and analysis class. See jacksorbetter.h/cpp files to see how to create a game
      */
     explicit PokerGame(const QString &gameName);
 
     /**
-     * @brief      Virtual destructor
+     * @brief Virtual destructor
      */
     virtual ~PokerGame();
 
@@ -53,74 +53,36 @@ public:
     const QString gameName() const;
 
     /**
-     * @brief      Choose the pay table
+     * @brief determineHandAndWin is where the actual hand evaluation logic and winnings shall be determined by classes
+     *                            inheriting from this abstract base class
      *
-     * @param[in]  credits     Credit / bet to spend towards each hand - must be between 1 and 5
-     *
-     * @throws     runtime_error if an invalid number of credits was proposed ("Invalid number of credits for game")
+     * @param[in]  gameHand       A set of PlayingCards comprising the player's hand construction
+     * @param[in]  nbCreditsBet   Number of credits the player has staked for gameHand
+     * @param[out] winningHand    QString buffer to write the winning hand (if any)
+     * @param[out] creditsWon     Number of credits the player is entitled to win based on the gameHand and bet
      */
-    void setCreditsPerBet(quint8 credits);
+    virtual void determineHandAndWin(const Hand &gameHand,
+                                     quint32     nbCreditsBet,
+                                     QString    &winningHand,
+                                     quint32    &creditsWon) = 0;
 
     /**
-     * @brief      Gets current pay table selection
+     * @brief currentPayTable extracts the relevant paytable based on how many credits would be bet
      *
-     * @return     number of credits currently bet
-     */
-    quint8 getCreditsPerBet() const;
-
-    /**
-     * @brief      Analyze a hand to see what (if any) winnings will apply
-     *
-     * @param[in]  gameHand    Reference to the hand that the game currently has
-     */
-    virtual void analyzeHand(const Hand &gameHand) = 0;
-
-    /**
-     * @brief      handResult
-     *
-     * @return     Hardcoded string representing the results of the hand analysis
-     *
-     * @note       analyzeHand must be run first
-     */
-    QString handResult() const;
-
-    /**
-     * @brief      Determines how many credits should be awarded to the player given the credits bet and hand result
-     *
-     * @return     Number of credits won per the final hand
-     *
-     * @note       analyzeHand must be run first
-     */
-    quint32 getWinnings() const;
-
-    /**
-     * @brief      Resets the hand processor
-     */
-    void reset();
-
-    /**
-     * @brief currentPayTable extracts the relevant paytable based on the current creditsPerBet value
-     *
+     * @param[in]  nbCredPerBet   number of credits that would be bet
      * @param[out] payoutForBet   vector of strings (name of hand) and int (payout value for that hand)
      */
-    void currentPayTable(QVector<QPair<const QString, int> > &payoutForBet) const;
+    void currentPayTable(quint32 nbCredPerBet, QVector<QPair<const QString, int> > &payoutForBet) const;
 
 protected:
     /**
-     * @brief      handResult
+     * @brief creditBetValid determines if a valid number of credits was requested for betting
      *
-     * @param[in]  Hardcoded string representing the results of the hand analysis
+     * @param[in]  nbCredPerBet   Number of credits the player would like to bet
+     *
+     * @return     true if the number of credits are supported, false otherwise
      */
-    void setHandResult(QString handResult);
-
-    /**
-     * @brief      Determines how many credits should be awarded to the player given the credits bet and hand result
-     *
-     * @return     Number of credits won per the final hand
-     *
-     * @note       analyzeHand must be run first
-     */
-    void setWinnings(quint32 winningCredits);
+    bool creditBetValid(quint32 nbCredPerBet) const;
 
     /**
      * @brief _handPayouts is where sub classes inheriting from a PokerGame should save their payout tables
@@ -129,9 +91,6 @@ protected:
 
 private:
     QString             _gameName;
-    quint8              _credPerBet;
-    quint32             _winnings;
-    QString             _handResult;
 };
 
 #endif // POKERGAME_H

--- a/src/ui/gameaccountwindow.cpp
+++ b/src/ui/gameaccountwindow.cpp
@@ -145,18 +145,53 @@ void GameAccountWindow::startGame(PokerGame *gameLogicPointer)
 void GameAccountWindow::changeNumberOfHands(int increaseDecrease)
 {
     int currentHandCount = ui->handsToPlayLCD->value();
+    int nextHandCount    = 1;
+
+    // Because of rendering constraints, adjust the number of hands not 1-by-1 but with specific values
     if (increaseDecrease == -1) {
-        if (currentHandCount > 1) {
-            ui->handsToPlayLCD->display(currentHandCount - 1);
-        } else {
-            ui->handsToPlayLCD->display(10);
+        switch (currentHandCount) {
+        case 1:
+//            nextHandCount = 100;
+            nextHandCount = 25;
+            break;
+        case 5:
+            nextHandCount = 3;
+            break;
+        case 10:
+            nextHandCount = 5;
+            break;
+        case 25:
+            nextHandCount = 10;
+            break;
+//        case 100:
+//            nextHandCount = 25;
+//            break;
+        default:
+            nextHandCount = 1;
         }
     } else if (increaseDecrease == 1) {
-        if (currentHandCount < 10) {
-            ui->handsToPlayLCD->display(currentHandCount + 1);
-        } else {
-            ui->handsToPlayLCD->display(1);
+        switch (currentHandCount) {
+        case 1:
+            nextHandCount = 3;
+            break;
+        case 3:
+            nextHandCount = 5;
+            break;
+        case 5:
+            nextHandCount = 10;
+            break;
+        case 10:
+            nextHandCount = 25;
+            break;
+//        case 25:
+//            nextHandCount = 100;
+//            break;
+        default:
+            nextHandCount = 1;
         }
     }
+
+    // Update the UI control with the new value
+    ui->handsToPlayLCD->display(nextHandCount);
 }
 

--- a/src/ui/gameaccountwindow.cpp
+++ b/src/ui/gameaccountwindow.cpp
@@ -108,6 +108,12 @@ GameAccountWindow::GameAccountWindow(QWidget *parent)
     // Number of Hands Increment / Decrement
     connect(ui->nbHandsDec, &QPushButton::clicked, this, [=]() {changeNumberOfHands(-1);});
     connect(ui->nbHandsInc, &QPushButton::clicked, this, [=]() {changeNumberOfHands( 1);});
+
+    // Uncomment to make window full-screen
+//    this->setWindowState(this->windowState() | Qt::WindowFullScreen);
+
+    // Uncomment the line below to mask the mouse pointer
+//    QApplication::setOverrideCursor(Qt::BlankCursor);
 }
 
 GameAccountWindow::~GameAccountWindow()

--- a/src/ui/gameaccountwindow.ui
+++ b/src/ui/gameaccountwindow.ui
@@ -14,9 +14,9 @@
    <string>VidPokerTerminal</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">font-size: 15pt;
-background-color: rgb(6, 139, 3);
-color: rgb(255, 255, 255);</string>
+   <string notr="true">background-color: rgb(6, 139, 3);
+color: rgb(255, 255, 255);
+/*font-size: 14pt;*/</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1,0,0">
@@ -51,7 +51,7 @@ QPushButton:pressed {
     border-width: 2px;
     border-color: lawngreen;
 }
-</string>
+font-size: 14pt;</string>
       </property>
       <property name="frameShape">
        <enum>QFrame::StyledPanel</enum>
@@ -144,7 +144,7 @@ QPushButton:pressed {
     border-width: 2px;
     border-color: lawngreen;
 }
-</string>
+font-size: 14pt;</string>
       </property>
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
@@ -179,7 +179,7 @@ QPushButton:pressed {
     border-width: 2px;
     border-color: lawngreen;
 }
-</string>
+font-size: 14pt;</string>
       </property>
       <property name="frameShape">
        <enum>QFrame::StyledPanel</enum>
@@ -267,11 +267,14 @@ QPushButton:pressed {
     </item>
     <item>
      <widget class="QFrame" name="quitAboutArea">
+      <property name="cursor">
+       <cursorShape>ForbiddenCursor</cursorShape>
+      </property>
       <property name="styleSheet">
        <string notr="true">background-color: rgb(0, 0, 0);</string>
       </property>
       <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
+       <enum>QFrame::NoFrame</enum>
       </property>
       <property name="frameShadow">
        <enum>QFrame::Raised</enum>
@@ -289,7 +292,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -297,7 +299,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:focused {
     color: red;
@@ -305,7 +306,6 @@ QPushButton:focused {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -313,7 +313,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>
@@ -337,7 +336,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -345,7 +343,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:focused {
     color: red;
@@ -353,7 +350,6 @@ QPushButton:focused {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -361,7 +357,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>
@@ -385,7 +380,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -393,7 +387,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:focused {
     color: red;
@@ -401,7 +394,6 @@ QPushButton:focused {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -409,7 +401,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>
@@ -433,7 +424,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -441,7 +431,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:focused {
     color: red;
@@ -449,7 +438,6 @@ QPushButton:focused {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -457,7 +445,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>
@@ -481,7 +468,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -489,7 +475,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:focused {
     color: red;
@@ -497,7 +482,6 @@ QPushButton:focused {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -505,7 +489,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>

--- a/src/ui/gameorchestratorwindow.cpp
+++ b/src/ui/gameorchestratorwindow.cpp
@@ -83,7 +83,7 @@ GameOrchestratorWindow::GameOrchestratorWindow(Account   &playerAccount,
     /*
      * Primary hand setup: this hand will control the hold status of *all* additional hands for multi-hand games
      */
-    HandWidget *PrimaryHand = new HandWidget(false, this);
+    HandWidget *PrimaryHand = new HandWidget(false, QSize(125, 175), "32", "", this);
     ui->primaryHand->layout()->addWidget(PrimaryHand);
 
     // Connect [primary] hand widgets to the game orchestrator to show results, winnings
@@ -113,11 +113,80 @@ GameOrchestratorWindow::GameOrchestratorWindow(Account   &playerAccount,
      * Additional Hands (optional)
      * Using push_front so that when rendering the hands it will go from bottom to top
      */
+    ui->multipleHand->layout()->deleteLater();
+    QGridLayout *secondaryHandsLayout = new QGridLayout(this);
+    ui->multipleHand->setLayout(secondaryHandsLayout);
     _addedHands.reserve(_handsToPlay);
-    for (int extraHands = 1; extraHands < _handsToPlay; ++extraHands) {
-        HandWidget *ExtraHand = new HandWidget(true, this);
-        ui->multipleHand->layout()->addWidget(ExtraHand);
-        _addedHands.push_front(ExtraHand);
+
+    if (_handsToPlay == 3) {
+        for (int extraHands = 1; extraHands < _handsToPlay; ++extraHands) {
+            HandWidget *ExtraHand = new HandWidget(true, QSize(125, 175), "32", "", this);
+            secondaryHandsLayout->addWidget(ExtraHand, extraHands - 1, 0);
+            _addedHands.push_front(ExtraHand);
+        }
+    } else if (_handsToPlay == 5) {
+        int column = 1;
+        int row    = 0;
+        for (int extraHands = 1; extraHands < _handsToPlay; ++extraHands) {
+            HandWidget *ExtraHand = new HandWidget(true, QSize(80, 110), "24", "", this);
+            secondaryHandsLayout->addWidget(ExtraHand, row, column);
+            _addedHands.push_front(ExtraHand);
+
+            // Determine the row and column of the next hand to render
+            column = column - 1;
+            if (column == -1) {
+                ++row;
+                column = 1;
+            }
+        }
+    } else if (_handsToPlay == 10) {
+        int column = 2;
+        int row    = 0;
+        for (int extraHands = 1; extraHands < _handsToPlay; ++extraHands) {
+            HandWidget *ExtraHand = new HandWidget(true, QSize(60, 80), "18", "", this);
+            secondaryHandsLayout->addWidget(ExtraHand, row, column);
+            _addedHands.push_front(ExtraHand);
+
+            // Determine the row and column of the next hand to render
+            column = column - 1;
+            if (column == -1) {
+                ++row;
+                column = 2;
+            }
+        }
+    } else if (_handsToPlay == 25) {
+        int column = 4;
+        int row    = 0;
+        for (int extraHands = 1; extraHands < _handsToPlay; ++extraHands) {
+            // Need to shrink down the payout text when there are this many shown
+            HandWidget *ExtraHand = new HandWidget(true, QSize(25, 35), "9", "9", this);
+            secondaryHandsLayout->addWidget(ExtraHand, row, column);
+            _addedHands.push_front(ExtraHand);
+
+            // Determine the row and column of the next hand to render
+            column = column - 1;
+            if (column == -1) {
+                ++row;
+                column = 4;
+            }
+        }
+    } else if (_handsToPlay == 100) {
+        // Mostly a thought experiment ... this runs really poorly on the Pi Zero and the HandWidget probably needs
+        // some reengineering to support hands of this size on 1080p screens
+        int column = 9;
+        int row    = 0;
+        for (int extraHands = 1; extraHands < _handsToPlay; ++extraHands) {
+            HandWidget *ExtraHand = new HandWidget(true, QSize(35, 50), "9", "", this);
+            secondaryHandsLayout->addWidget(ExtraHand, row, column);
+            _addedHands.push_front(ExtraHand);
+
+            // Determine the row and column of the next hand to render
+            column = column - 1;
+            if (column == -1) {
+                ++row;
+                column = 9;
+            }
+        }
     }
 
     connect(_gameOrc, &GameOrchestrator::secondaryCardRevealed, this, &GameOrchestratorWindow::updateSecondaryHandCard);
@@ -222,6 +291,9 @@ void GameOrchestratorWindow::disableDealDraw(bool dealDrawDisabled)
 {
     // Do not let the deal/draw button get pressed again while the orchestrator is working
     ui->drawDealButton->setDisabled(dealDrawDisabled);
+
+    // Do not let the speed adjuster get pressed either
+    ui->speedButton->setDisabled(dealDrawDisabled);
 }
 
 void GameOrchestratorWindow::syncDealDraw()

--- a/src/ui/gameorchestratorwindow.cpp
+++ b/src/ui/gameorchestratorwindow.cpp
@@ -123,9 +123,6 @@ GameOrchestratorWindow::~GameOrchestratorWindow()
     // Cleanup heap-allocated objects
     delete _gameOrc;
     delete ui;
-
-    // TODO: need to implement a stateless _gameLogic! Ensure that the game logic does not have any game state leftover
-    _gameLogic->reset();
 }
 
 void GameOrchestratorWindow::resizeEvent(QResizeEvent *event)

--- a/src/ui/gameorchestratorwindow.h
+++ b/src/ui/gameorchestratorwindow.h
@@ -31,6 +31,8 @@ namespace Ui {
 class GameOrchestratorWindow;
 }
 
+class HandWidget;
+
 /**
  * @brief The GameOrchestratorWindow provides a graphical interface to a generic PokerGame logic via an orchestrator
  *        which handles dealing, holding, drawing, betting, winning operations with an Account which tracks all funds.
@@ -59,6 +61,9 @@ public slots:
     // set showDraw to true so the button for deal/draw only says "Draw", otherwise it is "Deal"
     void dealToDraw(bool showDraw);
 
+    // Disables the deal-draw button so it cannot be operated
+    void disableDealDraw(bool dealDrawDisabled);
+
     // Resets the cards BEFORE calling the dealDraw of the orchestrator (prevents exceptions/collisions between threads)
     void syncDealDraw();
 
@@ -78,6 +83,15 @@ public slots:
     void holdCard4(bool cardHeld);
     void holdCard5(bool cardHeld);
 
+    // Update Secondary Hand at secoHandPos
+    void updateSecondaryHandCard(int secoHandPos, int cardPos, PlayingCard cardToShow, bool show);
+
+    // Show the win of a secondary hand at secoHandPos
+    void secondaryWinTextAndAmt(int secoHandPos, const QString &handString, quint32 winning);
+
+    // Flips over all cards of all hands
+    void flipAllHands();
+
 signals:
     // Should be emitted before calling the dealDraw to give the UI time to catch up before the orchestrator delivers
     // any new cards
@@ -87,11 +101,12 @@ signals:
     void readyForDealDraw();
 
 private:
-    Account          &_playerCredits;
-    GameOrchestrator *_gameOrc;
-    PokerGame        *_gameLogic;
-    int               _handsToPlay;
-    QThread          *_gameEventProcessor;
+    Account              &_playerCredits;
+    GameOrchestrator     *_gameOrc;
+    PokerGame            *_gameLogic;
+    int                   _handsToPlay;
+    QVector<HandWidget*>  _addedHands;
+    QThread              *_gameEventProcessor;
     Ui::GameOrchestratorWindow *ui;
 };
 

--- a/src/ui/gameorchestratorwindow.h
+++ b/src/ui/gameorchestratorwindow.h
@@ -36,6 +36,19 @@ class HandWidget;
 /**
  * @brief The GameOrchestratorWindow provides a graphical interface to a generic PokerGame logic via an orchestrator
  *        which handles dealing, holding, drawing, betting, winning operations with an Account which tracks all funds.
+ *
+ * @note  Multiple-Hand Support
+ *        The orchestrator can play as many hands at a time as a player wishes to wager. The player interacts with a
+ *        primary hand which renders at deal time. Only this hannd can have card held, it will hold the same card on
+ *        all other hands too. Then at draw time, all the hands will be filled with their shuffled decks.
+ *        Constraints about realistic betting amounts and how many hands can fit on a screen mean an upper limit of
+ *        100 simultaneous hands. The way these "secondary hands" are drawn to the screen depends on how many are
+ *        played. The increment is not uniform either, but stepped: 1 -> 3 -> 5 -> 10 -> 25 ---> 100 (!)
+ *
+ *        Be advised that screen constraints get a little troublesome above 10 hands, especially on 1080p monitors.
+ *
+ *        In the constructor, the font and pixel sizes can be updated to work with your screen situation (since this
+ *        was originally designed for desktop monitors and then kludged into smaller screen resolutions).
  */
 class GameOrchestratorWindow : public QMainWindow
 {

--- a/src/ui/gameorchestratorwindow.ui
+++ b/src/ui/gameorchestratorwindow.ui
@@ -42,7 +42,7 @@ color: rgb(255, 255, 255);</string>
          <property name="frameShadow">
           <enum>QFrame::Raised</enum>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
+         <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0">
           <item>
            <widget class="QFrame" name="multipleHand">
             <property name="frameShape">
@@ -79,9 +79,6 @@ color: rgb(255, 255, 255);</string>
          <layout class="QVBoxLayout" name="verticalLayout_5">
           <item>
            <widget class="QFrame" name="payoutTable">
-            <property name="styleSheet">
-             <string notr="true">font-size: 18pt;</string>
-            </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>
@@ -94,15 +91,15 @@ color: rgb(255, 255, 255);</string>
                <property name="text">
                 <string>Poker Game Name</string>
                </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
               </widget>
              </item>
              <item>
               <widget class="QTableWidget" name="payoutDisplay">
                <property name="focusPolicy">
                 <enum>Qt::NoFocus</enum>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">font-size: 16pt;</string>
                </property>
                <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
@@ -145,6 +142,9 @@ color: rgb(255, 255, 255);</string>
           </item>
           <item>
            <widget class="QFrame" name="accountBets">
+            <property name="styleSheet">
+             <string notr="true">font-size: 16pt;</string>
+            </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>
@@ -152,45 +152,31 @@ color: rgb(255, 255, 255);</string>
              <enum>QFrame::Raised</enum>
             </property>
             <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+             <item row="1" column="0">
+              <widget class="QLabel" name="betLabel">
+               <property name="text">
+                <string>Bet</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="creditsLabel">
+               <property name="text">
+                <string>Credits</string>
+               </property>
+              </widget>
+             </item>
              <item row="0" column="0">
               <widget class="QLabel" name="winLabel">
-               <property name="styleSheet">
-                <string notr="true">font-size: 20pt;</string>
-               </property>
                <property name="text">
                 <string>Win</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
              <item row="0" column="1">
-              <widget class="QLCDNumber" name="winAmount">
-               <property name="styleSheet">
-                <string notr="true">font-size: 20pt;</string>
-               </property>
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Plain</enum>
-               </property>
-               <property name="digitCount">
-                <number>11</number>
-               </property>
-               <property name="segmentStyle">
-                <enum>QLCDNumber::Flat</enum>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="betLabel">
-               <property name="styleSheet">
-                <string notr="true">font-size: 20pt;</string>
-               </property>
+              <widget class="QLabel" name="winAmount">
                <property name="text">
-                <string>Bet</string>
+                <string>0</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -198,28 +184,9 @@ color: rgb(255, 255, 255);</string>
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QLCDNumber" name="betAmount">
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Plain</enum>
-               </property>
-               <property name="digitCount">
-                <number>11</number>
-               </property>
-               <property name="segmentStyle">
-                <enum>QLCDNumber::Flat</enum>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="creditsLabel">
-               <property name="styleSheet">
-                <string notr="true">font-size: 20pt;</string>
-               </property>
+              <widget class="QLabel" name="betAmount">
                <property name="text">
-                <string>Credits</string>
+                <string>0</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -227,18 +194,12 @@ color: rgb(255, 255, 255);</string>
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QLCDNumber" name="creditsAmount">
-               <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
+              <widget class="QLabel" name="creditsAmount">
+               <property name="text">
+                <string>0</string>
                </property>
-               <property name="frameShadow">
-                <enum>QFrame::Plain</enum>
-               </property>
-               <property name="digitCount">
-                <number>11</number>
-               </property>
-               <property name="segmentStyle">
-                <enum>QLCDNumber::Flat</enum>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
               </widget>
              </item>
@@ -253,6 +214,9 @@ color: rgb(255, 255, 255);</string>
     </item>
     <item>
      <widget class="QFrame" name="softKeyArea">
+      <property name="cursor">
+       <cursorShape>ForbiddenCursor</cursorShape>
+      </property>
       <property name="styleSheet">
        <string notr="true">background-color: rgb(0, 0, 0);</string>
       </property>
@@ -272,7 +236,6 @@ color: rgb(255, 255, 255);</string>
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -280,7 +243,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -288,7 +250,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>
@@ -309,7 +270,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -317,7 +277,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -325,7 +284,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>
@@ -346,7 +304,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -354,7 +311,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -362,7 +318,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>
@@ -383,7 +338,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -391,7 +345,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -399,7 +352,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>
@@ -420,7 +372,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     color: black;
@@ -428,7 +379,6 @@ QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:pressed {
     color: yellow;
@@ -436,7 +386,6 @@ QPushButton:pressed {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
          </property>

--- a/src/ui/gameorchestratorwindow.ui
+++ b/src/ui/gameorchestratorwindow.ui
@@ -51,7 +51,6 @@ color: rgb(255, 255, 255);</string>
             <property name="frameShadow">
              <enum>QFrame::Raised</enum>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_3"/>
            </widget>
           </item>
           <item>
@@ -214,9 +213,6 @@ color: rgb(255, 255, 255);</string>
     </item>
     <item>
      <widget class="QFrame" name="softKeyArea">
-      <property name="cursor">
-       <cursorShape>ForbiddenCursor</cursorShape>
-      </property>
       <property name="styleSheet">
        <string notr="true">background-color: rgb(0, 0, 0);</string>
       </property>

--- a/src/ui/handwidget.cpp
+++ b/src/ui/handwidget.cpp
@@ -19,23 +19,35 @@
 #include "ui_handwidget.h"
 
 const QString HandWidget::cardBackStyle =
-        "background-color:rgb(0,66,188);border-radius:10px;color:rgb(227,227,227);font-size:20pt;";
+        "background-color:rgb(0,66,188);border-radius:10px;color:rgb(227,227,227);";
 const QString HandWidget::cardFrontStyle =
-        "background-color:rgb(227,227,227);border-radius:10px;font-size:48pt;";
+        "background-color:rgb(227,227,227);border-radius:10px;font-size:32pt;";
 
-HandWidget::HandWidget(QWidget *parent) :
+HandWidget::HandWidget(bool extraHand, QWidget *parent) :
     QWidget(parent),
+    _displayCardsOnly(extraHand),
     ui(new Ui::HandWidget)
 {
     ui->setupUi(this);
 
     // There are 5 cards, selecting their respective hold buttons should indicate to the game orchestrator they are
     // to be preserved and not re-drawn
-    connect(ui->holdBtnCard1, &QPushButton::toggled, this, &HandWidget::card1Hold);
-    connect(ui->holdBtnCard2, &QPushButton::toggled, this, &HandWidget::card2Hold);
-    connect(ui->holdBtnCard3, &QPushButton::toggled, this, &HandWidget::card3Hold);
-    connect(ui->holdBtnCard4, &QPushButton::toggled, this, &HandWidget::card4Hold);
-    connect(ui->holdBtnCard5, &QPushButton::toggled, this, &HandWidget::card5Hold);
+    if (!_displayCardsOnly) {
+        // Primary hand: show and allow use of the hold buttons
+        connect(ui->holdBtnCard1, &QPushButton::toggled, this, &HandWidget::card1Hold);
+        connect(ui->holdBtnCard2, &QPushButton::toggled, this, &HandWidget::card2Hold);
+        connect(ui->holdBtnCard3, &QPushButton::toggled, this, &HandWidget::card3Hold);
+        connect(ui->holdBtnCard4, &QPushButton::toggled, this, &HandWidget::card4Hold);
+        connect(ui->holdBtnCard5, &QPushButton::toggled, this, &HandWidget::card5Hold);
+    } else {
+        // Extra hand(s): only for display, no hold button control
+        ui->holdBtnCard1->deleteLater();
+        ui->holdBtnCard2->deleteLater();
+        ui->holdBtnCard3->deleteLater();
+        ui->holdBtnCard4->deleteLater();
+        ui->holdBtnCard5->deleteLater();
+        ui->resultLabel->setText("");
+    }
 }
 
 HandWidget::~HandWidget()
@@ -188,11 +200,13 @@ void HandWidget::showCardBacks(bool card1, bool card2, bool card3, bool card4, b
 void HandWidget::resetAll()
 {
     // Unset holds
-    ui->holdBtnCard1->setChecked(false);
-    ui->holdBtnCard2->setChecked(false);
-    ui->holdBtnCard3->setChecked(false);
-    ui->holdBtnCard4->setChecked(false);
-    ui->holdBtnCard5->setChecked(false);
+    if (!_displayCardsOnly) {
+        ui->holdBtnCard1->setChecked(false);
+        ui->holdBtnCard2->setChecked(false);
+        ui->holdBtnCard3->setChecked(false);
+        ui->holdBtnCard4->setChecked(false);
+        ui->holdBtnCard5->setChecked(false);
+    }
 
     // Flip cards back
     ui->card1->setText("Chad's\nCasino");

--- a/src/ui/handwidget.cpp
+++ b/src/ui/handwidget.cpp
@@ -18,19 +18,39 @@
 #include "handwidget.h"
 #include "ui_handwidget.h"
 
-const QString HandWidget::cardBackStyle =
-        "border-radius:10px;color:rgb(227,227,227);"
-        "background-color: qlineargradient(spread:repeat, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(0, 0, 74, 255), stop:1 rgba(0, 0, 255, 255));";
-const QString HandWidget::cardFrontStyle =
-        "border-radius:10px;font-size:32pt;"
-        "background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(190, 190, 190, 255), stop:1 rgba(255, 255, 255, 255));";
-
-HandWidget::HandWidget(bool extraHand, QWidget *parent) :
+HandWidget::HandWidget(bool           extraHand,
+                       const QSize   &cardSize,
+                       const QString &fontSize,
+                       const QString &winFontSize,
+                       QWidget       *parent) :
     QWidget(parent),
     _displayCardsOnly(extraHand),
+    _cardSize(cardSize),
+    _fontSize(fontSize),
+    _winFontSize(winFontSize),
     ui(new Ui::HandWidget)
 {
     ui->setupUi(this);
+
+    // Apply styling to the cards
+    _cardBackStyleSheet = "border-radius:10px;color:rgb(227,227,227);"
+            "background-color: qlineargradient(spread:repeat, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(0, 0, 74, 255),"
+            " stop:1 rgba(0, 0, 255, 255));";
+
+    _cardFrontStyleSheet = "border-radius:10px;"
+            "background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(185, 185, 185, 255),"
+            "stop:1 rgba(255, 255, 255, 255));font-size:" + _fontSize + "pt;";
+
+    if (!_winFontSize.isEmpty()) {
+        ui->resultLabel->setStyleSheet("font-size:" + _winFontSize + "pt;");
+    }
+
+    // And make sure the size obeys what the UI requested
+    ui->card1->setMinimumSize(_cardSize);
+    ui->card2->setMinimumSize(_cardSize);
+    ui->card3->setMinimumSize(_cardSize);
+    ui->card4->setMinimumSize(_cardSize);
+    ui->card5->setMinimumSize(_cardSize);
 
     // There are 5 cards, selecting their respective hold buttons should indicate to the game orchestrator they are
     // to be preserved and not re-drawn
@@ -64,7 +84,7 @@ void HandWidget::winningTextAndAmount(const QString &handString, quint32 winning
     } else if (winning == 0) {
         ui->resultLabel->setText(handString);
     } else {
-        ui->resultLabel->setText(handString + " - Win +" + QString::number(winning));
+        ui->resultLabel->setText(handString + " +" + QString::number(winning));
     }
 }
 
@@ -151,23 +171,23 @@ void HandWidget::revealCard(int cardIdx, PlayingCard card)
     switch (cardIdx) {
     case 0:
         ui->card1->setText(valueSymbol + "\n" + suitSymbol);
-        ui->card1->setStyleSheet(cardFrontStyle + colorStyleSheet);
+        ui->card1->setStyleSheet(_cardFrontStyleSheet + colorStyleSheet);
         break;
     case 1:
         ui->card2->setText(valueSymbol + "\n" + suitSymbol);
-        ui->card2->setStyleSheet(cardFrontStyle + colorStyleSheet);
+        ui->card2->setStyleSheet(_cardFrontStyleSheet + colorStyleSheet);
         break;
     case 2:
         ui->card3->setText(valueSymbol + "\n" + suitSymbol);
-        ui->card3->setStyleSheet(cardFrontStyle + colorStyleSheet);
+        ui->card3->setStyleSheet(_cardFrontStyleSheet + colorStyleSheet);
         break;
     case 3:
         ui->card4->setText(valueSymbol + "\n" + suitSymbol);
-        ui->card4->setStyleSheet(cardFrontStyle + colorStyleSheet);
+        ui->card4->setStyleSheet(_cardFrontStyleSheet + colorStyleSheet);
         break;
     case 4:
         ui->card5->setText(valueSymbol + "\n" + suitSymbol);
-        ui->card5->setStyleSheet(cardFrontStyle + colorStyleSheet);
+        ui->card5->setStyleSheet(_cardFrontStyleSheet + colorStyleSheet);
         break;
     default:
         // Should not happen!
@@ -179,23 +199,23 @@ void HandWidget::showCardBacks(bool card1, bool card2, bool card3, bool card4, b
 {
     if (card1) {
         ui->card1->setText("");
-        ui->card1->setStyleSheet(cardBackStyle);
+        ui->card1->setStyleSheet(_cardBackStyleSheet);
     }
     if (card2) {
         ui->card2->setText("");
-        ui->card2->setStyleSheet(cardBackStyle);
+        ui->card2->setStyleSheet(_cardBackStyleSheet);
     }
     if (card3) {
         ui->card3->setText("");
-        ui->card3->setStyleSheet(cardBackStyle);
+        ui->card3->setStyleSheet(_cardBackStyleSheet);
     }
     if (card4) {
         ui->card4->setText("");
-        ui->card4->setStyleSheet(cardBackStyle);
+        ui->card4->setStyleSheet(_cardBackStyleSheet);
     }
     if (card5) {
         ui->card5->setText("");
-        ui->card5->setStyleSheet(cardBackStyle);
+        ui->card5->setStyleSheet(_cardBackStyleSheet);
     }
 }
 
@@ -212,15 +232,15 @@ void HandWidget::resetAll()
 
     // Flip cards back
     ui->card1->setText("");
-    ui->card1->setStyleSheet(cardBackStyle);
+    ui->card1->setStyleSheet(_cardBackStyleSheet);
     ui->card2->setText("");
-    ui->card2->setStyleSheet(cardBackStyle);
+    ui->card2->setStyleSheet(_cardBackStyleSheet);
     ui->card3->setText("");
-    ui->card3->setStyleSheet(cardBackStyle);
+    ui->card3->setStyleSheet(_cardBackStyleSheet);
     ui->card4->setText("");
-    ui->card4->setStyleSheet(cardBackStyle);
+    ui->card4->setStyleSheet(_cardBackStyleSheet);
     ui->card5->setText("");
-    ui->card5->setStyleSheet(cardBackStyle);
+    ui->card5->setStyleSheet(_cardBackStyleSheet);
 
     // Hide any winning string
     ui->resultLabel->setText("");

--- a/src/ui/handwidget.cpp
+++ b/src/ui/handwidget.cpp
@@ -19,9 +19,11 @@
 #include "ui_handwidget.h"
 
 const QString HandWidget::cardBackStyle =
-        "background-color:rgb(0,66,188);border-radius:10px;color:rgb(227,227,227);";
+        "border-radius:10px;color:rgb(227,227,227);"
+        "background-color: qlineargradient(spread:repeat, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(0, 0, 74, 255), stop:1 rgba(0, 0, 255, 255));";
 const QString HandWidget::cardFrontStyle =
-        "background-color:rgb(227,227,227);border-radius:10px;font-size:32pt;";
+        "border-radius:10px;font-size:32pt;"
+        "background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(190, 190, 190, 255), stop:1 rgba(255, 255, 255, 255));";
 
 HandWidget::HandWidget(bool extraHand, QWidget *parent) :
     QWidget(parent),
@@ -176,23 +178,23 @@ void HandWidget::revealCard(int cardIdx, PlayingCard card)
 void HandWidget::showCardBacks(bool card1, bool card2, bool card3, bool card4, bool card5)
 {
     if (card1) {
-        ui->card1->setText("Chad's\nCasino");
+        ui->card1->setText("");
         ui->card1->setStyleSheet(cardBackStyle);
     }
     if (card2) {
-        ui->card2->setText("Chad's\nCasino");
+        ui->card2->setText("");
         ui->card2->setStyleSheet(cardBackStyle);
     }
     if (card3) {
-        ui->card3->setText("Chad's\nCasino");
+        ui->card3->setText("");
         ui->card3->setStyleSheet(cardBackStyle);
     }
     if (card4) {
-        ui->card4->setText("Chad's\nCasino");
+        ui->card4->setText("");
         ui->card4->setStyleSheet(cardBackStyle);
     }
     if (card5) {
-        ui->card5->setText("Chad's\nCasino");
+        ui->card5->setText("");
         ui->card5->setStyleSheet(cardBackStyle);
     }
 }
@@ -209,15 +211,15 @@ void HandWidget::resetAll()
     }
 
     // Flip cards back
-    ui->card1->setText("Chad's\nCasino");
+    ui->card1->setText("");
     ui->card1->setStyleSheet(cardBackStyle);
-    ui->card2->setText("Chad's\nCasino");
+    ui->card2->setText("");
     ui->card2->setStyleSheet(cardBackStyle);
-    ui->card3->setText("Chad's\nCasino");
+    ui->card3->setText("");
     ui->card3->setStyleSheet(cardBackStyle);
-    ui->card4->setText("Chad's\nCasino");
+    ui->card4->setText("");
     ui->card4->setStyleSheet(cardBackStyle);
-    ui->card5->setText("Chad's\nCasino");
+    ui->card5->setText("");
     ui->card5->setStyleSheet(cardBackStyle);
 
     // Hide any winning string

--- a/src/ui/handwidget.h
+++ b/src/ui/handwidget.h
@@ -34,7 +34,14 @@ class HandWidget : public QWidget
     const static QString cardFrontStyle;
 
 public:
-    explicit HandWidget(QWidget *parent = nullptr);
+    /**
+     * @brief HandWidget is a display/select module for a single hand of a poker game UI
+     *
+     * @param[in]  extraHand      true to indicate 'extra' hands (no hold controls), false for the primary hand
+     * @param[in]  parent         standard QObject hierarchy / memory management pointer
+     */
+    explicit HandWidget(bool extraHand, QWidget *parent = nullptr);
+
     ~HandWidget();
 
 public slots:
@@ -61,6 +68,8 @@ signals:
     void card5Hold(bool cardIsHeld);
 
 private:
+    bool _displayCardsOnly;
+
     // Actual Qt widgets
     Ui::HandWidget *ui;
 };

--- a/src/ui/handwidget.h
+++ b/src/ui/handwidget.h
@@ -29,18 +29,21 @@ class HandWidget;
 class HandWidget : public QWidget
 {
     Q_OBJECT
-
-    const static QString cardBackStyle;
-    const static QString cardFrontStyle;
-
 public:
     /**
      * @brief HandWidget is a display/select module for a single hand of a poker game UI
      *
      * @param[in]  extraHand      true to indicate 'extra' hands (no hold controls), false for the primary hand
+     * @param[in]  cardSize       size of the cards to draw in the hand (a null QSize should be used for primary hand)
+     * @param[in]  cardFontSize   CSS-compatible font size in pt --> Example: fonstSize == "14" --> "font-size:14pt;"
+     * @param[in]  winFontSize    CSS-compatible font size in pt for the winning string (use "" if keeping same as app.)
      * @param[in]  parent         standard QObject hierarchy / memory management pointer
      */
-    explicit HandWidget(bool extraHand, QWidget *parent = nullptr);
+    explicit HandWidget(bool           extraHand,
+                        const QSize   &cardSize,
+                        const QString &cardFontSize,
+                        const QString &winFontSize,
+                        QWidget       *parent = nullptr);
 
     ~HandWidget();
 
@@ -68,7 +71,12 @@ signals:
     void card5Hold(bool cardIsHeld);
 
 private:
-    bool _displayCardsOnly;
+    bool    _displayCardsOnly;
+    QSize   _cardSize;
+    QString _fontSize;
+    QString _winFontSize;
+    QString _cardFrontStyleSheet;
+    QString _cardBackStyleSheet;
 
     // Actual Qt widgets
     Ui::HandWidget *ui;

--- a/src/ui/handwidget.ui
+++ b/src/ui/handwidget.ui
@@ -52,10 +52,10 @@
          </size>
         </property>
         <property name="styleSheet">
-         <string notr="true">background-color: rgb(0, 66, 188);
-border-color: rgb(250, 250, 250);
+         <string notr="true">border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-border-radius: 10px;</string>
+border-radius: 10px;
+background-color: qlineargradient(spread:repeat, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(0, 0, 74, 255), stop:1 rgba(0, 0, 255, 255));</string>
         </property>
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -67,8 +67,7 @@ border-radius: 10px;</string>
          <number>4</number>
         </property>
         <property name="text">
-         <string>Chad's
-Casino</string>
+         <string/>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -84,10 +83,10 @@ Casino</string>
          </size>
         </property>
         <property name="styleSheet">
-         <string notr="true">background-color: rgb(0, 66, 188);
-border-color: rgb(250, 250, 250);
+         <string notr="true">border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-border-radius: 10px;</string>
+border-radius: 10px;
+background-color: qlineargradient(spread:repeat, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(0, 0, 74, 255), stop:1 rgba(0, 0, 255, 255));</string>
         </property>
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -99,8 +98,7 @@ border-radius: 10px;</string>
          <number>4</number>
         </property>
         <property name="text">
-         <string>Chad's
-Casino</string>
+         <string/>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -116,10 +114,10 @@ Casino</string>
          </size>
         </property>
         <property name="styleSheet">
-         <string notr="true">background-color: rgb(0, 66, 188);
-border-color: rgb(250, 250, 250);
+         <string notr="true">border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-border-radius: 10px;</string>
+border-radius: 10px;
+background-color: qlineargradient(spread:repeat, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(0, 0, 74, 255), stop:1 rgba(0, 0, 255, 255));</string>
         </property>
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -131,8 +129,7 @@ border-radius: 10px;</string>
          <number>4</number>
         </property>
         <property name="text">
-         <string>Chad's
-Casino</string>
+         <string/>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -161,10 +158,10 @@ Casino</string>
          </size>
         </property>
         <property name="styleSheet">
-         <string notr="true">background-color: rgb(0, 66, 188);
-border-color: rgb(250, 250, 250);
+         <string notr="true">border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-border-radius: 10px;</string>
+border-radius: 10px;
+background-color: qlineargradient(spread:repeat, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(0, 0, 74, 255), stop:1 rgba(0, 0, 255, 255));</string>
         </property>
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -176,8 +173,7 @@ border-radius: 10px;</string>
          <number>4</number>
         </property>
         <property name="text">
-         <string>Chad's
-Casino</string>
+         <string/>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -193,10 +189,10 @@ Casino</string>
          </size>
         </property>
         <property name="styleSheet">
-         <string notr="true">background-color: rgb(0, 66, 188);
-border-color: rgb(250, 250, 250);
+         <string notr="true">border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-border-radius: 10px;</string>
+border-radius: 10px;
+background-color: qlineargradient(spread:repeat, x1:0, y1:0, x2:1, y2:1, stop:0 rgba(0, 0, 74, 255), stop:1 rgba(0, 0, 255, 255));</string>
         </property>
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
@@ -208,8 +204,7 @@ border-radius: 10px;</string>
          <number>4</number>
         </property>
         <property name="text">
-         <string>Chad's
-Casino</string>
+         <string/>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>

--- a/src/ui/handwidget.ui
+++ b/src/ui/handwidget.ui
@@ -6,23 +6,34 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>960</width>
-    <height>376</height>
+    <width>689</width>
+    <height>281</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">QCheckBox:checked {color: rgb(125,30,0); background-color: rgb(250,250,0);}</string>
+   <string notr="true">QCheckBox:checked {
+  color: rgb(125,30,0);
+  background-color: rgb(250,250,0);
+}
+</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item>
     <widget class="QFrame" name="cardArea">
      <property name="frameShape">
@@ -34,23 +45,16 @@
      <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,0,0,0,0,1">
       <item row="0" column="4">
        <widget class="QLabel" name="card4">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="minimumSize">
          <size>
-          <width>180</width>
-          <height>250</height>
+          <width>125</width>
+          <height>175</height>
          </size>
         </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-font-size: 20pt;
 border-radius: 10px;</string>
         </property>
         <property name="frameShape">
@@ -73,23 +77,16 @@ Casino</string>
       </item>
       <item row="0" column="3">
        <widget class="QLabel" name="card3">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="minimumSize">
          <size>
-          <width>180</width>
-          <height>250</height>
+          <width>125</width>
+          <height>175</height>
          </size>
         </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-font-size: 20pt;
 border-radius: 10px;</string>
         </property>
         <property name="frameShape">
@@ -112,23 +109,16 @@ Casino</string>
       </item>
       <item row="0" column="5">
        <widget class="QLabel" name="card5">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="minimumSize">
          <size>
-          <width>180</width>
-          <height>250</height>
+          <width>125</width>
+          <height>175</height>
          </size>
         </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-font-size: 20pt;
 border-radius: 10px;</string>
         </property>
         <property name="frameShape">
@@ -164,23 +154,16 @@ Casino</string>
       </item>
       <item row="0" column="1">
        <widget class="QLabel" name="card1">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="minimumSize">
          <size>
-          <width>180</width>
-          <height>250</height>
+          <width>125</width>
+          <height>175</height>
          </size>
         </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-font-size: 20pt;
 border-radius: 10px;</string>
         </property>
         <property name="frameShape">
@@ -203,23 +186,16 @@ Casino</string>
       </item>
       <item row="0" column="2">
        <widget class="QLabel" name="card2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
         <property name="minimumSize">
          <size>
-          <width>180</width>
-          <height>250</height>
+          <width>125</width>
+          <height>175</height>
          </size>
         </property>
         <property name="styleSheet">
          <string notr="true">background-color: rgb(0, 66, 188);
 border-color: rgb(250, 250, 250);
 color: rgb(227, 227, 227);
-font-size: 20pt;
 border-radius: 10px;</string>
         </property>
         <property name="frameShape">
@@ -267,13 +243,11 @@ Casino</string>
     border-style: flat;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:checked {
     color: yellow;
@@ -281,7 +255,6 @@ QPushButton:checked {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
         </property>
@@ -310,13 +283,11 @@ QPushButton:checked {
     border-style: flat;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:checked {
     color: yellow;
@@ -324,7 +295,6 @@ QPushButton:checked {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
         </property>
@@ -353,13 +323,11 @@ QPushButton:checked {
     border-style: flat;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:checked {
     color: yellow;
@@ -367,7 +335,6 @@ QPushButton:checked {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
         </property>
@@ -396,13 +363,11 @@ QPushButton:checked {
     border-style: flat;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:checked {
     color: yellow;
@@ -410,7 +375,6 @@ QPushButton:checked {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
         </property>
@@ -439,13 +403,11 @@ QPushButton:checked {
     border-style: flat;
     border-width: 2px;
     border-color: gray;
-    font-size: 15pt;
 }
 QPushButton {
     border-style: outset;
     border-width: 2px;
     border-color: gold;
-    font-size: 15pt;
 }
 QPushButton:checked {
     color: yellow;
@@ -453,7 +415,6 @@ QPushButton:checked {
     border-style: outset;
     border-width: 2px;
     border-color: yellow;
-    font-size: 15pt;
 }
 </string>
         </property>
@@ -479,8 +440,8 @@ QPushButton:checked {
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="styleSheet">
-      <string notr="true">font-size: 18pt;</string>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="text">
       <string>Select bet level, then press 'Deal' to begin a game</string>
@@ -489,6 +450,19 @@ QPushButton:checked {
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/test/pokerhand_test.cpp
+++ b/test/pokerhand_test.cpp
@@ -24,11 +24,11 @@ namespace {
 // Test orchestrator function to hopefully make for less repetetive code
 void validateResult(PokerGame &myGame, const Hand &myHand, quint8 credits, quint32 expWinnings, const QString &expHand)
 {
-    myGame.setCreditsPerBet(credits);
-    myGame.analyzeHand(myHand);
-    QCOMPARE(myGame.getWinnings(), expWinnings);
-    QCOMPARE(myGame.handResult(), expHand);
-    myGame.reset();
+    QString retHand;
+    quint32 retWinnings;
+    myGame.determineHandAndWin(myHand, credits, retHand, retWinnings);
+    QCOMPARE(retWinnings, expWinnings);
+    QCOMPARE(retHand, expHand);
 }
 }
 


### PR DESCRIPTION
The back-end game orchestrator will now process several hands in a betting round, the number can be completely arbitrary, but on the front-end, the realities of rendering an arbitrary number of cards in a scalable way was ... insurmountable. So as a result the number of hands that can be played at a time is controlled by the main Account / Game Select screen (1, 3, 5, 10, 25 simultaneous hands).
Anyone wishing to deploy the UI should look at the Orchestrator Window's UI to adjust font sizes and card size pixels accordingly.