### PR TITLE
Only Enable Hold Buttons When Orchestrator is Ready

### DIFF
--- a/poker/gameorchestrator.cpp
+++ b/poker/gameorchestrator.cpp
@@ -162,12 +162,16 @@ void GameOrchestrator::dealDraw()
             _gameAnalyzer->determineHandAndWin(_gameCards[0].second, _betsPerHand, handAnalyResult, handWinCredits);
             emit primaryHandUpdated(handAnalyResult, 0);
             emit operating(false);
+            emit readyForHolds(true);
         }
     } else {
         /*
          * Second stage of a game, hold cards selected, so draw only non-held-cards, then analyze the win
          */
-        // First, flip the cards back over
+        // Do not allow holds
+        emit readyForHolds(false);
+
+        // Flip the cards back over
         bool flipCard1 = false;
         bool flipCard2 = false;
         bool flipCard3 = false;

--- a/poker/gameorchestrator.h
+++ b/poker/gameorchestrator.h
@@ -165,6 +165,11 @@ signals:
     void operating(bool handsDealing);
 
     /**
+     * @brief readyForHolds indicates that the orchestrator can accept hold operations
+     */
+    void readyForHolds(bool canAllowHolds);
+
+    /**
      * @brief primaryHandUpdated indicates the result of the hand analysis and any winnings associated with that hand
      */
     void primaryHandUpdated(const QString &handString, quint32 winning);

--- a/ui/gameorchestratorwindow.cpp
+++ b/ui/gameorchestratorwindow.cpp
@@ -94,7 +94,7 @@ GameOrchestratorWindow::GameOrchestratorWindow(Account   &playerAccount,
 
     // Card holding (for the primary hand) - set to disabled to start
     PrimaryHand->enableHolds(false);
-    connect(_gameOrc, &GameOrchestrator::gameInProgress, PrimaryHand, &HandWidget::enableHolds);
+    connect(_gameOrc, &GameOrchestrator::readyForHolds, PrimaryHand, &HandWidget::enableHolds);
 
     connect(PrimaryHand, &HandWidget::card1Hold, this, &GameOrchestratorWindow::holdCard1);
     connect(PrimaryHand, &HandWidget::card2Hold, this, &GameOrchestratorWindow::holdCard2);


### PR DESCRIPTION
When playing a game, the hold buttons are no longer "clickable" (enabled) until the signal from the game orchestrator says it is OK. This fixes strange bugs of cards looking like they were actually held but not really because a player could have held a card as the orchestrator was rendering them.